### PR TITLE
Add iterator support and improve Optional API

### DIFF
--- a/src/optional/optional.test.ts
+++ b/src/optional/optional.test.ts
@@ -95,4 +95,164 @@ test("Optional", async (t) => {
       .value_or(0);
     assert.strictEqual(transformedResult, 11);
   });
+
+  t.test("has correct Symbol.toStringTag", () => {
+    const someValue = optional.some("test");
+    const noneValue = optional.none<string>();
+
+    assert.strictEqual(someValue[Symbol.toStringTag], "Optional");
+    assert.strictEqual(noneValue[Symbol.toStringTag], "Optional");
+  });
+
+  t.test("accepts null and undefined as valid values", () => {
+    const nullOptional = optional.some(null);
+    assert.ok(nullOptional.is_some());
+    if (nullOptional.is_some()) {
+      assert.strictEqual(nullOptional.value, null);
+    }
+
+    const undefinedOptional = optional.some(undefined);
+    assert.ok(undefinedOptional.is_some());
+    if (undefinedOptional.is_some()) {
+      assert.strictEqual(undefinedOptional.value, undefined);
+    }
+  });
+
+  t.test("complex chaining with early termination", () => {
+    const result = optional
+      .some("start")
+      .map((v) => v + "-step1")
+      .and_then((v) =>
+        v.length > 5 ? optional.some(v) : optional.none<string>(),
+      )
+      .map((v) => v.toUpperCase())
+      .and_then((v) => optional.some(v.length));
+
+    assert.ok(result.is_some());
+    if (result.is_some()) {
+      assert.strictEqual(result.value, 11); // "START-STEP1".length
+    }
+
+    const terminatedResult = optional
+      .some("hi")
+      .map((v) => v + "-step1")
+      .and_then((v) => (v.length > 10 ? optional.some(v) : optional.none<string>()))
+      .map((v) => v.toUpperCase())
+      .and_then((v) => optional.some(v.length));
+
+    assert.ok(!terminatedResult.is_some());
+  });
+
+  t.test("or_else chains with multiple fallbacks", () => {
+    const result = optional
+      .none<string>()
+      .or_else(() => optional.none<string>())
+      .or_else(() => optional.some("fallback"));
+
+    assert.ok(result.is_some());
+    if (result.is_some()) {
+      assert.strictEqual(result.value, "fallback");
+    }
+  });
+
+  t.test("Generator/Iterator Interface", async (t) => {
+    t.test("Optional with value yields its value in for-of loop", () => {
+      const someOptional = optional.some(42);
+      const values: number[] = [];
+      
+      for (const value of someOptional) {
+        values.push(value);
+      }
+      
+      assert.strictEqual(values.length, 1);
+      assert.strictEqual(values[0], 42);
+    });
+
+    t.test("Empty Optional yields nothing in for-of loop", () => {
+      const emptyOptional = optional.none<number>();
+      const values: number[] = [];
+      
+      for (const value of emptyOptional) {
+        values.push(value);
+      }
+      
+      assert.strictEqual(values.length, 0);
+    });
+
+    t.test("can collect present values from array of optionals", () => {
+      const optionals = [
+        optional.some(1),
+        optional.none<number>(),
+        optional.some(3),
+        optional.some(5),
+        optional.none<number>()
+      ];
+      
+      const presentValues: number[] = [];
+      for (const opt of optionals) {
+        for (const value of opt) {
+          presentValues.push(value);
+        }
+      }
+      
+      assert.deepStrictEqual(presentValues, [1, 3, 5]);
+    });
+
+    t.test("generator works with Array.from", () => {
+      const someOptional = optional.some("hello");
+      const values = Array.from(someOptional);
+      
+      assert.strictEqual(values.length, 1);
+      assert.strictEqual(values[0], "hello");
+
+      const emptyOptional = optional.none<string>();
+      const emptyValues = Array.from(emptyOptional);
+      
+      assert.strictEqual(emptyValues.length, 0);
+    });
+
+    t.test("generator works with spread operator", () => {
+      const someOptional = optional.some(100);
+      const values = [...someOptional];
+      
+      assert.strictEqual(values.length, 1);
+      assert.strictEqual(values[0], 100);
+
+      const emptyOptional = optional.none<number>();
+      const emptyValues = [...emptyOptional];
+      
+      assert.strictEqual(emptyValues.length, 0);
+    });
+
+    t.test("can be used with destructuring", () => {
+      const someOptional = optional.some("test");
+      const [first, second] = someOptional;
+      
+      assert.strictEqual(first, "test");
+      assert.strictEqual(second, undefined);
+
+      const emptyOptional = optional.none<string>();
+      const [emptyFirst, emptySecond] = emptyOptional;
+      
+      assert.strictEqual(emptyFirst, undefined);
+      assert.strictEqual(emptySecond, undefined);
+    });
+
+    t.test("generator works with different value types", () => {
+      const stringOptional = optional.some("hello");
+      assert.deepStrictEqual([...stringOptional], ["hello"]);
+
+      const numberOptional = optional.some(42);
+      assert.deepStrictEqual([...numberOptional], [42]);
+
+      const objectOptional = optional.some({ name: "test" });
+      assert.deepStrictEqual([...objectOptional], [{ name: "test" }]);
+
+      const nullOptional = optional.some(null);
+      assert.deepStrictEqual([...nullOptional], [null]);
+
+      const undefinedOptional = optional.some(undefined);
+      assert.deepStrictEqual([...undefinedOptional], [undefined]);
+    });
+  });
 });

--- a/src/optional/optional.ts
+++ b/src/optional/optional.ts
@@ -173,7 +173,7 @@ export interface Optional<ValueType> {
  * A concrete implementation of the Optional interface.
  * `Optional` uses the `is_some()` [type predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) method to narrow the interface to `OptionalWithValue<ValueType>` when it contains a value.
  * Because of that behavior, it's best not to directly expose/use the constructor of this class.
- * Instead, prefer using `optional.some()` or `optional.none<ValueType>()` to create instatiations typed with only the public interface of `Optional<ValueType>`.
+ * Instead, prefer using `optional.some()` or `optional.none<ValueType>()` to create instantiations typed with only the public interface of `Optional<ValueType>`.
  *
  * @template ValueType - The type of the value that the Optional may contain.
  */

--- a/src/optional/optional.ts
+++ b/src/optional/optional.ts
@@ -26,7 +26,7 @@ type NoneType = typeof none_value;
 /**
  * The public interface of an Optional value. An Optional either contains a value of type `ValueType` or is empty.
  *
- * Optionals should be constructed using `optional.some()` or `optional.none()`.
+ * Optionals should be constructed using `optional.some()` or `optional.none<ValueType>()`.
  * These functions return objects implementing the `Optional` interface.
  *
  * The value of an Optional can only be accessed after checking `is_some()`.
@@ -63,7 +63,7 @@ export interface Optional<ValueType> {
    *
    * example:
    * ```ts
-   * const maybeValue = optional.none<string>(none);
+   * const maybeValue = optional.none<string>();
    * console.log(maybeValue.value_or("Default")); // prints "Default"
    * ```
    *
@@ -83,7 +83,7 @@ export interface Optional<ValueType> {
    *   console.log(maybe.value); // prints "HELLO"
    * }
    * // without a value
-   * const empty = optional.none<string>(none).map((v) => v.toUpperCase());
+   * const empty = optional.none<string>().map((v) => v.toUpperCase());
    * if (!empty.is_some()) {
    *   console.log("No value"); // prints "No value"
    * }
@@ -119,7 +119,7 @@ export interface Optional<ValueType> {
    *
    * example:
    * ```ts
-   * const maybe = optional.none<string>(none).or_else(() => optional.some("Default"));
+   * const maybe = optional.none<string>().or_else(() => optional.some("Default"));
    * if (maybe.is_some()) {
    *   console.log(maybe.value); // prints "Default"
    * }
@@ -129,6 +129,43 @@ export interface Optional<ValueType> {
    */
   or_else(fn: () => Optional<ValueType>): Optional<ValueType>;
 
+  /**
+   * Returns a generator that yields the contained value if this Optional has a value.
+   * If this Optional is empty, the generator yields nothing (completes immediately).
+   * This allows for easy iteration over present values in for-of loops and other iterator contexts.
+   * 
+   * @returns A generator that yields the value if present, otherwise yields nothing
+   * 
+   * @example
+   * ```typescript
+   * const someValue = optional.some(42);
+   * for (const value of someValue) {
+   *   console.log(value); // 42
+   * }
+   * 
+   * const emptyValue = optional.none<number>();
+   * for (const value of emptyValue) {
+   *   console.log("This won't execute");
+   * }
+   * 
+   * // Useful for collecting present values from multiple optionals
+   * const optionals = [
+   *   optional.some(1),
+   *   optional.none<number>(),
+   *   optional.some(3)
+   * ];
+   * 
+   * const values = [];
+   * for (const opt of optionals) {
+   *   for (const value of opt) {
+   *     values.push(value);
+   *   }
+   * }
+   * console.log(values); // [1, 3]
+   * ```
+   */
+  [Symbol.iterator](): Generator<ValueType, void, unknown>;
+
   get [Symbol.toStringTag](): "Optional";
 }
 
@@ -136,7 +173,7 @@ export interface Optional<ValueType> {
  * A concrete implementation of the Optional interface.
  * `Optional` uses the `is_some()` [type predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) method to narrow the interface to `OptionalWithValue<ValueType>` when it contains a value.
  * Because of that behavior, it's best not to directly expose/use the constructor of this class.
- * Instead, prefer using `optional.some()` or `optional.none()` to create instatiations typed with only the public interface of `Optional<ValueType>`.
+ * Instead, prefer using `optional.some()` or `optional.none<ValueType>()` to create instatiations typed with only the public interface of `Optional<ValueType>`.
  *
  * @template ValueType - The type of the value that the Optional may contain.
  */
@@ -172,6 +209,13 @@ class OptionalImpl<ValueType> implements Optional<ValueType> {
     }
     return this as unknown as Optional<NewValueType>;
   }
+
+  *[Symbol.iterator](): Generator<ValueType, void, unknown> {
+    if (this.is_some()) {
+      yield this.value;
+    }
+  }
+
   get [Symbol.toStringTag]() {
     return "Optional" as const;
   }

--- a/src/optional/readme.md
+++ b/src/optional/readme.md
@@ -37,6 +37,9 @@ export interface Optional<ValueType> {
 
   // Provide an alternative value if this Optional is empty.
   or_else(fn: () => Optional<ValueType>): Optional<ValueType>;
+
+  // Iterator support - yields the value if present, nothing if empty.
+  [Symbol.iterator](): Generator<ValueType, void, unknown>;
 }
 
 export const optional = {

--- a/src/optional/readme.test.ts
+++ b/src/optional/readme.test.ts
@@ -1,0 +1,121 @@
+import { test } from "node:test";
+import assert from "node:assert";
+
+import { optional, type Optional } from "./optional.ts";
+
+// Mock types for the example
+interface User {
+  id: string;
+  username: string;
+}
+
+interface Post {
+  id: string;
+  title: string;
+  content: string;
+}
+
+interface Comment {
+  id: string;
+  text: string;
+  author: string;
+}
+
+test("Readme examples work correctly", async (t) => {
+  t.test("Optional-based post and comments system", () => {
+    // Mock data
+    const users: User[] = [
+      { id: "1", username: "alice" },
+      { id: "2", username: "bob" }
+    ];
+
+    const posts: Post[] = [
+      { id: "1", title: "Post 1", content: "Content 1" },
+      { id: "2", title: "Post 2", content: "Content 2" }
+    ];
+
+    const comments: Comment[] = [
+      { id: "1", text: "Great post!", author: "bob" },
+      { id: "2", text: "I agree", author: "alice" },
+      { id: "3", text: "Nice work", author: "bob" }
+    ];
+
+    function getUserByUsername(username: string): Optional<User> {
+      const user = users.find(u => u.username === username);
+      return user ? optional.some(user) : optional.none();
+    }
+
+    function getUserPosts(userId: string): Optional<Post[]> {
+      // For this example, user "1" (alice) has posts, user "2" (bob) doesn't
+      if (userId === "1") {
+        return optional.some(posts);
+      }
+      return optional.none();
+    }
+
+    function getPostComments(postId: string): Optional<Comment[]> {
+      const postComments = comments.filter(c => true); // All comments for simplicity
+      return postComments.length > 0 ? optional.some(postComments) : optional.none();
+    }
+
+    function getUserPostsWithComments(
+      username: string): Optional<{ post: Post; comments: Comment[] }[]> {
+      return getUserByUsername(username)
+        .and_then(user => getUserPosts(user.id))
+        .and_then(userPosts => {
+          const postsWithComments = userPosts.map(post => ({
+            post,
+            comments: getPostComments(post.id).value_or([])
+          }));
+          const postsWithNonEmptyComments = postsWithComments.filter(
+            ({ comments }) => comments.length > 0
+          );
+          return postsWithNonEmptyComments.length > 0 
+            ? optional.some(postsWithNonEmptyComments)
+            : optional.none();
+        });
+    }
+
+    // Test successful case
+    const alicePostsWithComments = getUserPostsWithComments('alice');
+    assert.ok(alicePostsWithComments.is_some());
+    if (alicePostsWithComments.is_some()) {
+      assert.strictEqual(alicePostsWithComments.value.length, 2);
+      assert.strictEqual(alicePostsWithComments.value[0]!.post.title, "Post 1");
+      assert.strictEqual(alicePostsWithComments.value[0]!.comments.length, 3);
+    }
+
+    // Test user not found
+    const unknownUserPosts = getUserPostsWithComments('charlie');
+    assert.ok(!unknownUserPosts.is_some());
+
+    // Test user with no posts
+    const bobPostsWithComments = getUserPostsWithComments('bob');
+    assert.ok(!bobPostsWithComments.is_some());
+
+    // Test the conditional rendering pattern from readme
+    const postsWithComments = getUserPostsWithComments('alice');
+    let renderResult: string;
+    
+    if (postsWithComments.is_some()) {
+      // the `.value` property is only available after widening it by checking `is_some()`
+      renderResult = `Rendered ${postsWithComments.value.length} posts with comments`;
+    } else {
+      renderResult = "Rendered empty posts";
+    }
+    
+    assert.strictEqual(renderResult, "Rendered 2 posts with comments");
+
+    // Test the empty case rendering
+    const emptyPosts = getUserPostsWithComments('bob');
+    let emptyRenderResult: string;
+    
+    if (emptyPosts.is_some()) {
+      emptyRenderResult = `Rendered ${emptyPosts.value.length} posts with comments`;
+    } else {
+      emptyRenderResult = "Rendered empty posts";
+    }
+    
+    assert.strictEqual(emptyRenderResult, "Rendered empty posts");
+  });
+});


### PR DESCRIPTION
## Summary
- Add iterator support to Optional type via Symbol.iterator
- Improve JSDoc documentation with correct API examples
- Add comprehensive test coverage for iterator functionality
- Add Symbol.toStringTag for better debugging

## Test plan
- [x] Verify iterator works with for-of loops
- [x] Test Array.from and spread operator compatibility
- [x] Confirm destructuring assignment works
- [x] Validate iterator behavior with different value types
- [x] Ensure backwards compatibility with existing API