### PR TITLE
Add optional.from() and optional.from_async() helper methods

### DIFF
--- a/src/optional/optional.test.ts
+++ b/src/optional/optional.test.ts
@@ -107,15 +107,11 @@ test("Optional", async (t) => {
   t.test("accepts null and undefined as valid values", () => {
     const nullOptional = optional.some(null);
     assert.ok(nullOptional.is_some());
-    if (nullOptional.is_some()) {
-      assert.strictEqual(nullOptional.value, null);
-    }
+    assert.strictEqual(nullOptional.value, null);
 
     const undefinedOptional = optional.some(undefined);
     assert.ok(undefinedOptional.is_some());
-    if (undefinedOptional.is_some()) {
-      assert.strictEqual(undefinedOptional.value, undefined);
-    }
+    assert.strictEqual(undefinedOptional.value, undefined);
   });
 
   t.test("complex chaining with early termination", () => {
@@ -129,14 +125,14 @@ test("Optional", async (t) => {
       .and_then((v) => optional.some(v.length));
 
     assert.ok(result.is_some());
-    if (result.is_some()) {
-      assert.strictEqual(result.value, 11); // "START-STEP1".length
-    }
+    assert.strictEqual(result.value, 11); // "START-STEP1".length
 
     const terminatedResult = optional
       .some("hi")
       .map((v) => v + "-step1")
-      .and_then((v) => (v.length > 10 ? optional.some(v) : optional.none<string>()))
+      .and_then((v) =>
+        v.length > 10 ? optional.some(v) : optional.none<string>(),
+      )
       .map((v) => v.toUpperCase())
       .and_then((v) => optional.some(v.length));
 
@@ -150,20 +146,18 @@ test("Optional", async (t) => {
       .or_else(() => optional.some("fallback"));
 
     assert.ok(result.is_some());
-    if (result.is_some()) {
-      assert.strictEqual(result.value, "fallback");
-    }
+    assert.strictEqual(result.value, "fallback");
   });
 
   t.test("Generator/Iterator Interface", async (t) => {
     t.test("Optional with value yields its value in for-of loop", () => {
       const someOptional = optional.some(42);
       const values: number[] = [];
-      
+
       for (const value of someOptional) {
         values.push(value);
       }
-      
+
       assert.strictEqual(values.length, 1);
       assert.strictEqual(values[0], 42);
     });
@@ -171,11 +165,11 @@ test("Optional", async (t) => {
     t.test("Empty Optional yields nothing in for-of loop", () => {
       const emptyOptional = optional.none<number>();
       const values: number[] = [];
-      
+
       for (const value of emptyOptional) {
         values.push(value);
       }
-      
+
       assert.strictEqual(values.length, 0);
     });
 
@@ -185,55 +179,55 @@ test("Optional", async (t) => {
         optional.none<number>(),
         optional.some(3),
         optional.some(5),
-        optional.none<number>()
+        optional.none<number>(),
       ];
-      
+
       const presentValues: number[] = [];
       for (const opt of optionals) {
         for (const value of opt) {
           presentValues.push(value);
         }
       }
-      
+
       assert.deepStrictEqual(presentValues, [1, 3, 5]);
     });
 
     t.test("generator works with Array.from", () => {
       const someOptional = optional.some("hello");
       const values = Array.from(someOptional);
-      
+
       assert.strictEqual(values.length, 1);
       assert.strictEqual(values[0], "hello");
 
       const emptyOptional = optional.none<string>();
       const emptyValues = Array.from(emptyOptional);
-      
+
       assert.strictEqual(emptyValues.length, 0);
     });
 
     t.test("generator works with spread operator", () => {
       const someOptional = optional.some(100);
       const values = [...someOptional];
-      
+
       assert.strictEqual(values.length, 1);
       assert.strictEqual(values[0], 100);
 
       const emptyOptional = optional.none<number>();
       const emptyValues = [...emptyOptional];
-      
+
       assert.strictEqual(emptyValues.length, 0);
     });
 
     t.test("can be used with destructuring", () => {
       const someOptional = optional.some("test");
       const [first, second] = someOptional;
-      
+
       assert.strictEqual(first, "test");
       assert.strictEqual(second, undefined);
 
       const emptyOptional = optional.none<string>();
       const [emptyFirst, emptySecond] = emptyOptional;
-      
+
       assert.strictEqual(emptyFirst, undefined);
       assert.strictEqual(emptySecond, undefined);
     });
@@ -254,5 +248,182 @@ test("Optional", async (t) => {
       const undefinedOptional = optional.some(undefined);
       assert.deepStrictEqual([...undefinedOptional], [undefined]);
     });
+  });
+
+  t.test("from() method", async (t) => {
+    t.test("wraps non-null/undefined values in some", () => {
+      const result = optional.from(() => "hello");
+      assert.ok(result.is_some());
+      assert.strictEqual(result.value, "hello");
+
+      const numberResult = optional.from(() => 42);
+      assert.ok(numberResult.is_some());
+      assert.strictEqual(numberResult.value, 42);
+
+      const objectResult = optional.from(() => ({ key: "value" }));
+      assert.ok(objectResult.is_some());
+      assert.deepStrictEqual(objectResult.value, { key: "value" });
+    });
+
+    t.test("wraps null values in none", () => {
+      const result = optional.from(() => null);
+      assert.ok(!result.is_some());
+    });
+
+    t.test("wraps undefined values in none", () => {
+      const result = optional.from(() => undefined);
+      assert.ok(!result.is_some());
+    });
+
+    t.test("works with functions that conditionally return null", () => {
+      function findItem(id: number): string | null {
+        return id === 1 ? "found" : null;
+      }
+
+      const foundResult = optional.from(() => findItem(1));
+      assert.ok(foundResult.is_some());
+      assert.strictEqual(foundResult.value, "found");
+
+      const notFoundResult = optional.from(() => findItem(2));
+      assert.ok(!notFoundResult.is_some());
+    });
+
+    t.test("works with DOM-like APIs", () => {
+      const mockDocument = {
+        getElementById: (id: string) => (id === "exists" ? { id } : null),
+      };
+
+      const foundElement = optional.from(() =>
+        mockDocument.getElementById("exists"),
+      );
+      assert.ok(foundElement.is_some());
+      assert.deepStrictEqual(foundElement.value, { id: "exists" });
+
+      const notFoundElement = optional.from(() =>
+        mockDocument.getElementById("missing"),
+      );
+      assert.ok(!notFoundElement.is_some());
+    });
+
+    t.test("can be chained with other Optional methods", () => {
+      const result = optional
+        .from(() => "hello")
+        .map((v) => v.toUpperCase())
+        .and_then((v) => optional.some(v.length))
+        .value_or(0);
+
+      assert.strictEqual(result, 5);
+
+      const nullResult = optional
+        .from(() => null as string | null)
+        .map((v) => v.toUpperCase())
+        .value_or("default");
+
+      assert.strictEqual(nullResult, "default");
+    });
+  });
+
+  t.test("from_async() method", async (t) => {
+    t.test("wraps non-null/undefined resolved values in some", async () => {
+      const result = await optional.from_async(async () => "hello");
+      assert.ok(result.is_some());
+      assert.strictEqual(result.value, "hello");
+
+      const numberResult = await optional.from_async(async () => 42);
+      assert.ok(numberResult.is_some());
+      assert.strictEqual(numberResult.value, 42);
+
+      const objectResult = await optional.from_async(async () => ({
+        key: "value",
+      }));
+      assert.ok(objectResult.is_some());
+      assert.deepStrictEqual(objectResult.value, { key: "value" });
+    });
+
+    t.test("wraps null resolved values in none", async () => {
+      const result = await optional.from_async(async () => null);
+      assert.ok(!result.is_some());
+    });
+
+    t.test("wraps undefined resolved values in none", async () => {
+      const result = await optional.from_async(async () => undefined);
+      assert.ok(!result.is_some());
+    });
+
+    t.test(
+      "works with async functions that conditionally return null",
+      async () => {
+        async function fetchUser(id: number): Promise<{ name: string } | null> {
+          await new Promise((resolve) => setTimeout(resolve, 1)); // Simulate async work
+          return id === 1 ? { name: "Alice" } : null;
+        }
+
+        const foundResult = await optional.from_async(() => fetchUser(1));
+        assert.ok(foundResult.is_some());
+        assert.deepStrictEqual(foundResult.value, { name: "Alice" });
+
+        const notFoundResult = await optional.from_async(() => fetchUser(2));
+        assert.ok(!notFoundResult.is_some());
+      },
+    );
+
+    t.test("works with fetch-like APIs", async () => {
+      const mockFetch = async (url: string) => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        if (url === "/api/success") {
+          return { ok: true, json: async () => ({ data: "success" }) };
+        }
+        return { ok: false, json: async () => null };
+      };
+
+      const successResult = await optional.from_async(async () => {
+        const response = await mockFetch("/api/success");
+        return response.ok ? await response.json() : null;
+      });
+
+      assert.ok(successResult.is_some());
+      assert.deepStrictEqual(successResult.value, { data: "success" });
+
+      const failureResult = await optional.from_async(async () => {
+        const response = await mockFetch("/api/failure");
+        return response.ok ? await response.json() : null;
+      });
+
+      assert.ok(!failureResult.is_some());
+    });
+
+    t.test("can be chained with other Optional methods", async () => {
+      const result = (await optional.from_async(async () => "hello"))
+        .map((v) => v.toUpperCase())
+        .and_then((v) => optional.some(v.length))
+        .value_or(0);
+
+      assert.strictEqual(result, 5);
+
+      const nullResult = (
+        await optional.from_async(async () => null as string | null)
+      )
+        .map((v) => v.toUpperCase())
+        .value_or("default");
+
+      assert.strictEqual(nullResult, "default");
+    });
+
+    t.test(
+      "handles promises that resolve to falsy but non-null values",
+      async () => {
+        const falseResult = await optional.from_async(async () => false);
+        assert.ok(falseResult.is_some());
+        assert.strictEqual(falseResult.value, false);
+
+        const zeroResult = await optional.from_async(async () => 0);
+        assert.ok(zeroResult.is_some());
+        assert.strictEqual(zeroResult.value, 0);
+
+        const emptyStringResult = await optional.from_async(async () => "");
+        assert.ok(emptyStringResult.is_some());
+        assert.strictEqual(emptyStringResult.value, "");
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Add `optional.from()` method to safely convert nullable function results to Optional instances
- Add `optional.from_async()` method for async functions that may return null/undefined
- Provides ergonomic API for wrapping existing nullable APIs in Optional monad pattern

## Changes
- `optional.from(fn)` executes function and returns `some(result)` for non-null values, `none()` for null/undefined
- `optional.from_async(fn)` async version that handles Promise-returning functions
- Comprehensive test coverage for both sync and async variants
- Support for DOM APIs, fetch patterns, and conditional null returns
- Proper TypeScript typing with `NonNullable<T>` for type safety

## Test plan
- [x] Verify sync `from()` handles non-null, null, and undefined returns correctly
- [x] Verify async `from_async()` handles Promise resolution to null/undefined
- [x] Test integration with existing Optional methods (map, and_then, etc.)
- [x] Test real-world patterns like DOM queries and API calls
- [x] Ensure falsy but non-null values (0, false, "") are preserved as `some()`