### PR TITLE
Add ESLint rules for type-safe error handling and null safety

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -10,6 +10,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 import type { TSESLint } from '@typescript-eslint/utils';
 import parser from '@typescript-eslint/parser';
+import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import { enforceOptionalUsage } from './src/optional/eslint-rule.ts';
 import { enforceResultUsage } from './src/result/eslint-rule.ts';
 
@@ -39,8 +40,12 @@ const config: TSESLint.FlatConfig.ConfigArray = [
     },
     plugins: {
       'ts-utils': tsUtilsPlugin,
+      '@typescript-eslint': typescriptEslint,
     },
     rules: {
+      // Disallow explicit any types
+      '@typescript-eslint/no-explicit-any': 'error',
+      
       // Enforce Optional usage instead of nullable unions
       'ts-utils/enforce-optional-usage': ['error', {
         allowExceptions: [], // Add function names to exclude

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,0 +1,73 @@
+/*
+Copyright (c) 2025 Allan Deutsch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import type { TSESLint } from '@typescript-eslint/utils';
+import parser from '@typescript-eslint/parser';
+import { enforceOptionalUsage } from './src/optional/eslint-rule.ts';
+import { enforceResultUsage } from './src/result/eslint-rule.ts';
+
+/**
+ * ESLint 9 flat configuration for ts-utils with custom TypeScript monadic rules.
+ * 
+ * This configuration demonstrates how to use the custom ESLint rules that enforce
+ * Optional and Result usage patterns for type-safe functional programming.
+ */
+// Define the custom plugin once
+const tsUtilsPlugin = {
+  rules: {
+    'enforce-optional-usage': enforceOptionalUsage,
+    'enforce-result-usage': enforceResultUsage,
+  },
+};
+
+const config: TSESLint.FlatConfig.ConfigArray = [
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: parser,
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      'ts-utils': tsUtilsPlugin,
+    },
+    rules: {
+      // Enforce Optional usage instead of nullable unions
+      'ts-utils/enforce-optional-usage': ['error', {
+        allowExceptions: [], // Add function names to exclude
+        autoFix: true,
+      }],
+      
+      // Enforce Result usage instead of throw/try-catch
+      'ts-utils/enforce-result-usage': ['error', {
+        allowExceptions: [], // Add function names to exclude
+        allowTestFiles: true, // Allow throw/try-catch in test files
+        autoFix: true,
+      }],
+    },
+  },
+  
+  // Configuration for test files with more relaxed rules
+  {
+    files: ['**/*.test.ts', '**/*.spec.ts', '**/test/**/*.ts', '**/tests/**/*.ts'],
+    rules: {
+      // More lenient rules for test files
+      'ts-utils/enforce-optional-usage': 'warn',
+      'ts-utils/enforce-result-usage': ['warn', {
+        allowTestFiles: true,
+        autoFix: false, // Don't auto-fix in test files
+      }],
+    },
+  },
+];
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,10 @@
       "devDependencies": {
         "@tsconfig/strictest": "^2.0.5",
         "@types/node": "^22.15.29",
-        "@typescript-eslint/parser": "^8.16.0",
-        "@typescript-eslint/rule-tester": "^8.16.0",
-        "@typescript-eslint/utils": "^8.16.0",
+        "@typescript-eslint/eslint-plugin": "^8.35.1",
+        "@typescript-eslint/parser": "^8.35.1",
+        "@typescript-eslint/rule-tester": "^8.35.1",
+        "@typescript-eslint/utils": "^8.35.1",
         "eslint": "^9.17.0",
         "jiti": "^2.4.2",
         "typescript": "^5.8.3"
@@ -145,6 +146,16 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -159,9 +170,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.30.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.0.tgz",
-      "integrity": "sha512-Wzw3wQwPvc9sHM+NjakWTcPx11mbZyiYHuwWa/QfZ7cIRX7WK54PSk7bdyXDaoaopUcMatv1zaQvOAAO8hCdww==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
+      "integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -334,26 +345,56 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "version": "22.16.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.0.tgz",
+      "integrity": "sha512-B2egV9wALML1JCpv3VQoQ+yesQKAmNMBIAY7OteVrikcOcAkWm+dGL6qpeCktPjAv6N1JLnhbNiqS35UpFyBsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.0.tgz",
-      "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.1.tgz",
+      "integrity": "sha512-9XNTlo7P7RJxbVeICaIIIEipqxLKguyh+3UbXuT2XQuFp6d8VOeDEGuz5IiX0dgZo8CiI6aOFLg4e8cF71SFVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.35.0",
-        "@typescript-eslint/types": "8.35.0",
-        "@typescript-eslint/typescript-estree": "8.35.0",
-        "@typescript-eslint/visitor-keys": "8.35.0",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/type-utils": "8.35.1",
+        "@typescript-eslint/utils": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.35.1",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.1.tgz",
+      "integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -369,14 +410,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.0.tgz",
-      "integrity": "sha512-41xatqRwWZuhUMF/aZm2fcUsOFKNcG28xqRSS6ZVr9BVJtGExosLAm5A1OxTjRMagx8nJqva+P5zNIGt8RIgbQ==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.1.tgz",
+      "integrity": "sha512-VYxn/5LOpVxADAuP3NrnxxHYfzVtQzLKeldIhDhzC8UHaiQvYlXvKuVho1qLduFbJjjy5U5bkGwa3rUGUb1Q6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.35.0",
-        "@typescript-eslint/types": "^8.35.0",
+        "@typescript-eslint/tsconfig-utils": "^8.35.1",
+        "@typescript-eslint/types": "^8.35.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -391,15 +432,15 @@
       }
     },
     "node_modules/@typescript-eslint/rule-tester": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.35.0.tgz",
-      "integrity": "sha512-1c8zz1uRy5Icd46+ziopy5k4Q/PxDAUeQxjw4vvSzPMCrbAbEA80ufsUJpBkIkc2iXEzlf4/J0Ha+4UTESSrNQ==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.35.1.tgz",
+      "integrity": "sha512-r1tvINTfn4zmSg3cD9VVKB5dbQv6bVATlZNXsqv152pe9MIJsOQ82XBvfHh/khxC7wCasKcwjUkFfHYUqYvCsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/parser": "8.35.0",
-        "@typescript-eslint/typescript-estree": "8.35.0",
-        "@typescript-eslint/utils": "8.35.0",
+        "@typescript-eslint/parser": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1",
+        "@typescript-eslint/utils": "8.35.1",
         "ajv": "^6.12.6",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "4.6.2",
@@ -417,14 +458,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.0.tgz",
-      "integrity": "sha512-+AgL5+mcoLxl1vGjwNfiWq5fLDZM1TmTPYs2UkyHfFhgERxBbqHlNjRzhThJqz+ktBqTChRYY6zwbMwy0591AA==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
+      "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.35.0",
-        "@typescript-eslint/visitor-keys": "8.35.0"
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -435,9 +476,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.0.tgz",
-      "integrity": "sha512-04k/7247kZzFraweuEirmvUj+W3bJLI9fX6fbo1Qm2YykuBvEhRTPl8tcxlYO8kZZW+HIXfkZNoasVb8EV4jpA==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.1.tgz",
+      "integrity": "sha512-K5/U9VmT9dTHoNowWZpz+/TObS3xqC5h0xAIjXPw+MNcKV9qg6eSatEnmeAwkjHijhACH0/N7bkhKvbt1+DXWQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -451,10 +492,34 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.1.tgz",
+      "integrity": "sha512-HOrUBlfVRz5W2LIKpXzZoy6VTZzMu2n8q9C2V/cFngIC5U1nStJgv0tMV4sZPzdf4wQm9/ToWUFPMN9Vq9VJQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.35.1",
+        "@typescript-eslint/utils": "8.35.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.0.tgz",
-      "integrity": "sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
+      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -466,16 +531,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.0.tgz",
-      "integrity": "sha512-F+BhnaBemgu1Qf8oHrxyw14wq6vbL8xwWKKMwTMwYIRmFFY/1n/9T/jpbobZL8vp7QyEUcC6xGrnAO4ua8Kp7w==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
+      "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.35.0",
-        "@typescript-eslint/tsconfig-utils": "8.35.0",
-        "@typescript-eslint/types": "8.35.0",
-        "@typescript-eslint/visitor-keys": "8.35.0",
+        "@typescript-eslint/project-service": "8.35.1",
+        "@typescript-eslint/tsconfig-utils": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -495,16 +560,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.0.tgz",
-      "integrity": "sha512-nqoMu7WWM7ki5tPgLVsmPM8CkqtoPUG6xXGeefM5t4x3XumOEKMoUZPdi+7F+/EotukN4R9OWdmDxN80fqoZeg==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
+      "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.35.0",
-        "@typescript-eslint/types": "8.35.0",
-        "@typescript-eslint/typescript-estree": "8.35.0"
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -519,13 +584,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.0.tgz",
-      "integrity": "sha512-zTh2+1Y8ZpmeQaQVIc/ZZxsx8UzgKJyNg1PTvjzC7WMhPSVS8bfDX34k1SrwOf016qd5RU3az2UxUNue3IfQ5g==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
+      "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.35.0",
+        "@typescript-eslint/types": "8.35.1",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -750,9 +815,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.30.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.0.tgz",
-      "integrity": "sha512-iN/SiPxmQu6EVkf+m1qpBxzUhE12YqFLOSySuOyVLJLEF9nzTf+h/1AJYc1JWzCnktggeNrjvQGLngDzXirU6g==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.1.tgz",
+      "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -762,7 +827,7 @@
         "@eslint/config-helpers": "^0.3.0",
         "@eslint/core": "^0.14.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.30.0",
+        "@eslint/js": "9.30.1",
         "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -862,6 +927,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
@@ -1105,6 +1180,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1116,9 +1198,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,325 @@
       "devDependencies": {
         "@tsconfig/strictest": "^2.0.5",
         "@types/node": "^22.15.29",
+        "@typescript-eslint/parser": "^8.16.0",
+        "@typescript-eslint/rule-tester": "^8.16.0",
+        "@typescript-eslint/utils": "^8.16.0",
+        "eslint": "^9.17.0",
+        "jiti": "^2.4.2",
         "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.0.tgz",
+      "integrity": "sha512-Wzw3wQwPvc9sHM+NjakWTcPx11mbZyiYHuwWa/QfZ7cIRX7WK54PSk7bdyXDaoaopUcMatv1zaQvOAAO8hCdww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.15.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@tsconfig/strictest": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@tsconfig/strictest/-/strictest-2.0.5.tgz",
       "integrity": "sha512-ec4tjL2Rr0pkZ5hww65c+EEPYwxOi4Ryv+0MtjeaSQRJyq322Q27eOQiFbuNgw2hpL4hB1/W/HBGk3VKS43osg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -29,6 +341,1283 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.0.tgz",
+      "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.35.0",
+        "@typescript-eslint/types": "8.35.0",
+        "@typescript-eslint/typescript-estree": "8.35.0",
+        "@typescript-eslint/visitor-keys": "8.35.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.0.tgz",
+      "integrity": "sha512-41xatqRwWZuhUMF/aZm2fcUsOFKNcG28xqRSS6ZVr9BVJtGExosLAm5A1OxTjRMagx8nJqva+P5zNIGt8RIgbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.35.0",
+        "@typescript-eslint/types": "^8.35.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/rule-tester": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.35.0.tgz",
+      "integrity": "sha512-1c8zz1uRy5Icd46+ziopy5k4Q/PxDAUeQxjw4vvSzPMCrbAbEA80ufsUJpBkIkc2iXEzlf4/J0Ha+4UTESSrNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/parser": "8.35.0",
+        "@typescript-eslint/typescript-estree": "8.35.0",
+        "@typescript-eslint/utils": "8.35.0",
+        "ajv": "^6.12.6",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "4.6.2",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.0.tgz",
+      "integrity": "sha512-+AgL5+mcoLxl1vGjwNfiWq5fLDZM1TmTPYs2UkyHfFhgERxBbqHlNjRzhThJqz+ktBqTChRYY6zwbMwy0591AA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.0",
+        "@typescript-eslint/visitor-keys": "8.35.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.0.tgz",
+      "integrity": "sha512-04k/7247kZzFraweuEirmvUj+W3bJLI9fX6fbo1Qm2YykuBvEhRTPl8tcxlYO8kZZW+HIXfkZNoasVb8EV4jpA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.0.tgz",
+      "integrity": "sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.0.tgz",
+      "integrity": "sha512-F+BhnaBemgu1Qf8oHrxyw14wq6vbL8xwWKKMwTMwYIRmFFY/1n/9T/jpbobZL8vp7QyEUcC6xGrnAO4ua8Kp7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.35.0",
+        "@typescript-eslint/tsconfig-utils": "8.35.0",
+        "@typescript-eslint/types": "8.35.0",
+        "@typescript-eslint/visitor-keys": "8.35.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.0.tgz",
+      "integrity": "sha512-nqoMu7WWM7ki5tPgLVsmPM8CkqtoPUG6xXGeefM5t4x3XumOEKMoUZPdi+7F+/EotukN4R9OWdmDxN80fqoZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.35.0",
+        "@typescript-eslint/types": "8.35.0",
+        "@typescript-eslint/typescript-estree": "8.35.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.0.tgz",
+      "integrity": "sha512-zTh2+1Y8ZpmeQaQVIc/ZZxsx8UzgKJyNg1PTvjzC7WMhPSVS8bfDX34k1SrwOf016qd5RU3az2UxUNue3IfQ5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.0.tgz",
+      "integrity": "sha512-iN/SiPxmQu6EVkf+m1qpBxzUhE12YqFLOSySuOyVLJLEF9nzTf+h/1AJYc1JWzCnktggeNrjvQGLngDzXirU6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.0",
+        "@eslint/core": "^0.14.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.30.0",
+        "@eslint/plugin-kit": "^0.3.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/typescript": {
@@ -51,6 +1640,55 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
   "devDependencies": {
     "@tsconfig/strictest": "^2.0.5",
     "@types/node": "^22.15.29",
-    "@typescript-eslint/parser": "^8.16.0",
-    "@typescript-eslint/rule-tester": "^8.16.0",
-    "@typescript-eslint/utils": "^8.16.0",
+    "@typescript-eslint/eslint-plugin": "^8.35.1",
+    "@typescript-eslint/parser": "^8.35.1",
+    "@typescript-eslint/rule-tester": "^8.35.1",
+    "@typescript-eslint/utils": "^8.35.1",
     "eslint": "^9.17.0",
     "jiti": "^2.4.2",
     "typescript": "^5.8.3"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "main": "index.js",
   "scripts": {
     "test": "node --test --experimental-test-coverage",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint \"src/**/*.ts\"",
+    "lint:file": "eslint",
+    "lint:fix": "eslint \"src/**/*.ts\" --fix"
   },
   "keywords": [],
   "author": "",
@@ -14,6 +17,11 @@
   "devDependencies": {
     "@tsconfig/strictest": "^2.0.5",
     "@types/node": "^22.15.29",
+    "@typescript-eslint/parser": "^8.16.0",
+    "@typescript-eslint/rule-tester": "^8.16.0",
+    "@typescript-eslint/utils": "^8.16.0",
+    "eslint": "^9.17.0",
+    "jiti": "^2.4.2",
     "typescript": "^5.8.3"
   }
 }

--- a/src/optional/eslint-rule.test.ts
+++ b/src/optional/eslint-rule.test.ts
@@ -94,6 +94,47 @@ ruleTester.run("enforce-optional-usage", enforceOptionalUsage, {
       code: `const item = optional.from(() => array.find(x => x.id === id));`,
     },
     {
+      name: "Arrow functions returning null inside optional.from() are valid",
+      code: `const result = optional.from(() => condition ? "value" : null);`,
+    },
+    {
+      name: "Arrow functions returning undefined inside optional.from() are valid", 
+      code: `const result = optional.from(() => condition ? 42 : undefined);`,
+    },
+    {
+      name: "Complex arrow functions with nullable returns inside optional.from() are valid",
+      code: `const user = optional.from(() => {
+        const found = users.find(u => u.id === targetId);
+        return found ? found : null;
+      });`,
+    },
+    {
+      name: "Nested arrow functions with nullable returns inside optional.from() are valid",
+      code: `const data = optional.from(() => 
+        items.map(item => item.value).find(val => val > threshold) || null
+      );`,
+    },
+    {
+      name: "Arrow functions returning null inside optional.from_async() are valid",
+      code: `const result = await optional.from_async(async () => {
+        const response = await fetch('/api/data');
+        return response.ok ? await response.json() : null;
+      });`,
+    },
+    {
+      name: "Mock functions with nullable returns inside optional.from_async() context are valid",
+      code: `const result = await optional.from_async(async () => {
+        const mockFetch = async (url: string) => {
+          if (url === "/api/success") {
+            return { ok: true, json: async () => ({ data: "success" }) };
+          }
+          return { ok: false, json: async () => null };
+        };
+        const response = await mockFetch("/api/test");
+        return response.ok ? await response.json() : null;
+      });`,
+    },
+    {
       name: "Result.match() calls with non-nullable returns should not trigger the rule",
       code: `const message = someResult.match({
         on_ok: (value) => \`Success: \${value}\`,

--- a/src/optional/eslint-rule.test.ts
+++ b/src/optional/eslint-rule.test.ts
@@ -67,6 +67,17 @@ ruleTester.run("enforce-optional-usage", enforceOptionalUsage, {
       }`,
     },
     {
+      name: "Arrow functions with implicit non-nullable returns are valid",
+      code: `const getValue = () => "hello";
+      const getNumber = () => 42;
+      const getBoolean = () => true;`,
+    },
+    {
+      name: "Arrow functions with implicit Optional returns are valid",
+      code: `const getOptional = () => optional.some("value");
+      const getNone = () => optional.none();`,
+    },
+    {
       name: "Methods returning Optional are valid",
       code: `class UserService {
         findById(id: string): Optional<User> {
@@ -81,6 +92,13 @@ ruleTester.run("enforce-optional-usage", enforceOptionalUsage, {
     {
       name: "Using optional.from() for array.find is valid",
       code: `const item = optional.from(() => array.find(x => x.id === id));`,
+    },
+    {
+      name: "Result.match() calls with non-nullable returns should not trigger the rule",
+      code: `const message = someResult.match({
+        on_ok: (value) => \`Success: \${value}\`,
+        on_error: (error) => \`Error: \${error.message}\`
+      });`,
     },
     {
       name: "Exception functions are allowed",
@@ -199,6 +217,54 @@ ruleTester.run("enforce-optional-usage", enforceOptionalUsage, {
     },
 
     {
+      name: "Arrow function with implicit return of null",
+      code: `const getNull = () => null;`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "T" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
+      name: "Arrow function with implicit return of undefined",
+      code: `const getUndefined = () => undefined;`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "T" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
+      name: "Arrow function with implicit conditional return containing null",
+      code: `const getConditional = () => condition ? "value" : null;`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "string" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
+      name: "Arrow function with implicit logical expression containing null",
+      code: `const getLogical = () => value || null;`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "T" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
       name: "Function returning union with null and undefined",
       code: `function getValue(): number | null | undefined {
         return null;
@@ -305,6 +371,21 @@ ruleTester.run("enforce-optional-usage", enforceOptionalUsage, {
         },
       ],
       output: `const matches = optional.from(() => text.match(/pattern/));`,
+    },
+
+    {
+      name: "Result.match() calls with nullable returns should trigger the rule",
+      code: `const result = someResult.match({
+        on_ok: (value) => value,
+        on_error: (error) => null
+      });`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "T" },
+        },
+      ],
+      // No auto-fix for function return types
     },
 
     {

--- a/src/optional/eslint-rule.test.ts
+++ b/src/optional/eslint-rule.test.ts
@@ -1,0 +1,394 @@
+/*
+Copyright (c) 2025 Allan Deutsch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import { test } from "node:test";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { enforceOptionalUsage } from "./eslint-rule.ts";
+
+// Configure RuleTester for Node.js test environment
+RuleTester.afterAll = () => { };
+RuleTester.it = test;
+RuleTester.describe = (name: string, fn: () => void) => test(name, fn);
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: "module",
+    },
+  },
+});
+
+ruleTester.run("enforce-optional-usage", enforceOptionalUsage, {
+  valid: [
+    {
+      name: "Functions returning Optional are valid",
+      code: `function findUser(id: string): Optional<User> {
+        return optional.some(user);
+      }`,
+    },
+    {
+      name: "Arrow functions returning Optional are valid",
+      code: `const getItem = (): Optional<string> => {
+        return optional.none();
+      }`,
+    },
+    {
+      name: "Methods returning Optional are valid",
+      code: `class UserService {
+        findById(id: string): Optional<User> {
+          return optional.some(user);
+        }
+      }`,
+    },
+    {
+      name: "Using optional.from() for nullable calls is valid",
+      code: `const element = optional.from(() => document.getElementById('test'));`,
+    },
+    {
+      name: "Using optional.from() for array.find is valid",
+      code: `const item = optional.from(() => array.find(x => x.id === id));`,
+    },
+    {
+      name: "Exception functions are allowed",
+      code: `function allowedFunction(): string | null {
+        return null;
+      }`,
+      options: [{ allowExceptions: ["allowedFunction"] }],
+    },
+    {
+      name: "Pattern exceptions are allowed",
+      code: `function testHelper(): string | null {
+        return null;
+      }`,
+      options: [{ allowExceptions: ["test*"] }],
+    },
+    {
+      name: "Non-nullable unions are fine",
+      code: `function getValue(): string | number {
+        return "test";
+      }`,
+    },
+    {
+      name: "Variables with Optional type are valid",
+      code: `const user: Optional<User> = optional.some(userData);`,
+    },
+  ],
+
+  invalid: [
+    {
+      name: "Function returning nullable type",
+      code: `function findUser(id: string): User | null {
+        return null;
+      }`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "User" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+    {
+      name: "Function returning null without a return type annotation",
+      code: `function returnNull() { return null; }`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "T" },
+        },
+      ],
+    },
+    {
+      name: "Arrow function returning nullable type",
+      code: `const getItem = (): string | undefined => {
+        return undefined;
+      }`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "string" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
+      name: "Function returning union with null and undefined",
+      code: `function getValue(): number | null | undefined {
+        return null;
+      }`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "number" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
+      name: "Method returning nullable type",
+      code: `class UserService {
+        findById(id: string): User | null {
+          return null;
+        }
+      }`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "User" },
+        },
+      ],
+      // No auto-fix for method return types
+    },
+
+    {
+      name: "Variable declaration with nullable union",
+      code: `const user: User | null = null;`,
+      errors: [
+        {
+          messageId: "noNullableUnion",
+          data: { type: "User" },
+        },
+      ],
+      // No auto-fix for variable declarations
+    },
+
+    {
+      name: "Variable with undefined union",
+      code: `let value: string | undefined;`,
+      errors: [
+        {
+          messageId: "noNullableUnion",
+          data: { type: "string" },
+        },
+      ],
+      // No auto-fix for variable declarations
+    },
+
+    {
+      name: "Direct call to getElementById (common nullable API)",
+      code: `const element = document.getElementById('test');`,
+      errors: [
+        {
+          messageId: "useOptionalFrom",
+        },
+      ],
+      output: `const element = optional.from(() => document.getElementById('test'));`,
+    },
+
+    {
+      name: "Direct call to querySelector",
+      code: `const element = document.querySelector('.class');`,
+      errors: [
+        {
+          messageId: "useOptionalFrom",
+        },
+      ],
+      output: `const element = optional.from(() => document.querySelector('.class'));`,
+    },
+
+    {
+      name: "Direct call to array.find",
+      code: `const item = array.find(x => x.id === 'test');`,
+      errors: [
+        {
+          messageId: "useOptionalFrom",
+        },
+      ],
+      output: `const item = optional.from(() => array.find(x => x.id === 'test'));`,
+    },
+
+    {
+      name: "Direct call to array.pop",
+      code: `const lastItem = items.pop();`,
+      errors: [
+        {
+          messageId: "useOptionalFrom",
+        },
+      ],
+      output: `const lastItem = optional.from(() => items.pop());`,
+    },
+
+    {
+      name: "Direct call to string.match",
+      code: `const matches = text.match(/pattern/);`,
+      errors: [
+        {
+          messageId: "useOptionalFrom",
+        },
+      ],
+      output: `const matches = optional.from(() => text.match(/pattern/));`,
+    },
+
+    {
+      name: "Primitive return types - number | null",
+      code: `function getNumber(): number | null {
+        return null;
+      }`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "number" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
+      name: "Primitive return types - string | undefined",
+      code: `function getString(): string | undefined {
+        return undefined;
+      }`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "string" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
+      name: "Primitive return types - boolean | null",
+      code: `function getBoolean(): boolean | null {
+        return null;
+      }`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "boolean" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
+      name: "Complex type union",
+      code: `function getComplexType(): SomeInterface | null | undefined {
+        return null;
+      }`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "SomeInterface" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
+      name: "Multi-type union falls back to T",
+      code: `function getMultiType(): (string | number) | null {
+        return null;
+      }`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "T" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
+      name: "Standalone null return type",
+      code: `function returnNull(): null {
+        return null;
+      }`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "T" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
+      name: "Standalone undefined return type",
+      code: `function returnUndefined(): undefined {
+        return undefined;
+      }`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "T" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
+      name: "Anonymous function expression",
+      code: `const handler = function(): string | null {
+        return null;
+      };`,
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "string" },
+        },
+      ],
+      // No auto-fix for function return types
+    },
+
+    {
+      name: "Multiple nullable APIs in one statement",
+      code: `const elements = [
+        document.getElementById('first'),
+        document.querySelector('.second')
+      ];`,
+      errors: [
+        {
+          messageId: "useOptionalFrom",
+        },
+        {
+          messageId: "useOptionalFrom",
+        },
+      ],
+      output: `const elements = [
+        optional.from(() => document.getElementById('first')),
+        optional.from(() => document.querySelector('.second'))
+      ];`,
+    },
+
+    {
+      name: "Direct function call to nullable API",
+      code: `const result = find(item => item.id === 'test');`,
+      errors: [
+        {
+          messageId: "useOptionalFrom",
+        },
+      ],
+      output: `const result = optional.from(() => find(item => item.id === 'test'));`,
+    },
+  ],
+});
+
+// Test with disabled auto-fix
+ruleTester.run("enforce-optional-usage (no auto-fix)", enforceOptionalUsage, {
+  valid: [],
+  invalid: [
+    {
+      name: "Function returning nullable type with auto-fix disabled",
+      code: `function findUser(): User | null { return null; }`,
+      options: [{ autoFix: false }],
+      errors: [
+        {
+          messageId: "noNullableReturn",
+          data: { type: "User" },
+        },
+      ],
+      // No output when autoFix is disabled
+    },
+  ],
+});

--- a/src/optional/eslint-rule.ts
+++ b/src/optional/eslint-rule.ts
@@ -20,8 +20,8 @@ type Options = [
 type MessageIds = "noNullableReturn" | "useOptionalFrom" | "noNullableUnion";
 
 const createRule = ESLintUtils.RuleCreator(
-  (name) =>
-    `https://github.com/masstronaut/ts-utils/blob/main/docs/rules/${name}.md`,
+  () =>
+    `https://github.com/masstronaut/ts-utils/blob/main/src/optional/readme.md`,
 );
 
 /**

--- a/src/optional/eslint-rule.ts
+++ b/src/optional/eslint-rule.ts
@@ -21,7 +21,7 @@ type MessageIds = "noNullableReturn" | "useOptionalFrom" | "noNullableUnion";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>
-    `https://github.com/your-org/ts-utils/blob/main/docs/rules/${name}.md`,
+    `https://github.com/masstronaut/ts-utils/blob/main/docs/rules/${name}.md`,
 );
 
 /**
@@ -134,12 +134,7 @@ export const enforceOptionalUsage = createRule<Options, MessageIds>({
     }
 
     function isInsideOptionalFrom(node: TSESTree.Node): boolean {
-      if (undefined === node.parent) {
-        return false;
-      }
-      // Check if this function is inside an optional.from() or optional.from_async() call
-      let parent: TSESTree.Node = node.parent;
-      let foundOptionalFromCall = false;
+      let parent: TSESTree.Node = node.parent!;
 
       while (parent) {
         if (
@@ -151,18 +146,10 @@ export const enforceOptionalUsage = createRule<Options, MessageIds>({
           (parent.callee.property.name === "from" ||
             parent.callee.property.name === "from_async")
         ) {
-          foundOptionalFromCall = true;
-        }
-
-        // If we found an optional.from call and we're still within its arguments,
-        // then this function is inside the optional.from context
-        if (foundOptionalFromCall) {
           return true;
         }
-        if (undefined === parent.parent) {
-          break;
-        }
-        parent = parent.parent;
+
+        parent = parent.parent!;
       }
       return false;
     }

--- a/src/optional/eslint-rule.ts
+++ b/src/optional/eslint-rule.ts
@@ -1,0 +1,293 @@
+/*
+Copyright (c) 2025 Allan Deutsch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+
+type Options = [
+  {
+    allowExceptions?: string[];
+    autoFix?: boolean;
+  },
+];
+
+type MessageIds = "noNullableReturn" | "useOptionalFrom" | "noNullableUnion";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/your-org/ts-utils/blob/main/docs/rules/${name}.md`,
+);
+
+/**
+ * ESLint rule that enforces Optional usage patterns instead of nullable returns and direct nullable function calls.
+ *
+ * This rule:
+ * - Disallows functions returning `T | null` or `T | undefined`
+ * - Suggests using `optional.from()` when calling functions that return nullable types
+ * - Provides auto-fix suggestions where possible
+ */
+export const enforceOptionalUsage = createRule<Options, MessageIds>({
+  name: "enforce-optional-usage",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Enforce Optional monad usage instead of nullable returns and direct nullable calls",
+    },
+    fixable: "code",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowExceptions: {
+            type: "array",
+            items: { type: "string" },
+            description: "Function names or patterns to exclude from the rule",
+          },
+          autoFix: {
+            type: "boolean",
+            description: "Enable automatic fixes",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noNullableReturn:
+        "Functions should return Optional<{{type}}> instead of {{type}} | null | undefined. Change the return type and update return statements to use optional.some(value) or optional.none().",
+      useOptionalFrom:
+        "Calls to functions returning nullable types should be wrapped with optional.from(). This ensures type-safe handling of non-values and avoids propagating them through the code.",
+      noNullableUnion:
+        "Union types with null/undefined should use Optional<{{type}}> instead of {{type}} | null | undefined. Change the type annotation and initialize with optional.some(value) or optional.none().",
+    },
+  },
+  defaultOptions: [{ allowExceptions: [], autoFix: true }],
+  create(context, [options]) {
+    const { allowExceptions = [], autoFix = true } = options;
+
+    function isNullableUnion(node: TSESTree.TSTypeAnnotation): boolean {
+      // Check for standalone null or undefined types
+      if (
+        node.typeAnnotation.type === "TSNullKeyword" ||
+        node.typeAnnotation.type === "TSUndefinedKeyword"
+      ) {
+        return true;
+      }
+
+      // Check for union types containing null or undefined
+      if (node.typeAnnotation.type !== "TSUnionType") return false;
+
+      const union = node.typeAnnotation;
+      return union.types.some(
+        (type) =>
+          type.type === "TSNullKeyword" || type.type === "TSUndefinedKeyword",
+      );
+    }
+
+    function getNonNullableType(
+      typeAnnotation: TSESTree.TSTypeAnnotation,
+    ): string {
+      // Handle standalone null/undefined types
+      if (typeAnnotation.typeAnnotation.type !== "TSUnionType") {
+        return "T"; // Fallback for other types
+      }
+
+      const union = typeAnnotation.typeAnnotation;
+      const nonNullTypes = union.types.filter(
+        (type) =>
+          type.type !== "TSNullKeyword" && type.type !== "TSUndefinedKeyword",
+      );
+
+      if (nonNullTypes.length === 1) {
+        const type = nonNullTypes[0];
+        if (
+          type &&
+          type.type === "TSTypeReference" &&
+          "typeName" in type &&
+          type.typeName &&
+          type.typeName.type === "Identifier"
+        ) {
+          return type.typeName.name;
+        }
+        if (type && type.type === "TSStringKeyword") return "string";
+        if (type && type.type === "TSNumberKeyword") return "number";
+        if (type && type.type === "TSBooleanKeyword") return "boolean";
+      }
+      return "T";
+    }
+
+    function isExceptionFunction(name: string): boolean {
+      return allowExceptions.some((exception) => {
+        if (exception.includes("*")) {
+          const pattern = new RegExp(exception.replace(/\*/g, ".*"));
+          return pattern.test(name);
+        }
+        return exception === name;
+      });
+    }
+
+    return {
+      // Check function return types (includes methods via FunctionExpression)
+      "FunctionDeclaration, FunctionExpression, ArrowFunctionExpression"(
+        node:
+          | TSESTree.FunctionDeclaration
+          | TSESTree.FunctionExpression
+          | TSESTree.ArrowFunctionExpression,
+      ) {
+        if (!node.returnType || !isNullableUnion(node.returnType)) return;
+
+        // Skip if this is a method function (handled by parent MethodDefinition selector)
+        if (
+          node.type === "FunctionExpression" &&
+          node.parent?.type === "MethodDefinition"
+        ) {
+          return;
+        }
+
+        const functionName =
+          (node.type === "FunctionDeclaration" && node.id?.name) ||
+          (node.parent?.type === "VariableDeclarator" &&
+            node.parent.id.type === "Identifier" &&
+            node.parent.id.name) ||
+          "anonymous";
+
+        if (isExceptionFunction(functionName)) return;
+
+        const baseType = getNonNullableType(node.returnType);
+
+        context.report({
+          node: node.returnType,
+          messageId: "noNullableReturn" as const,
+          data: { type: baseType },
+          // Disable auto-fix for function return types as it requires
+          // updating all return statements within the function body
+          fix: null,
+        });
+      },
+
+      // Check method return types
+      MethodDefinition(node: TSESTree.MethodDefinition) {
+        if (node.value.type !== "FunctionExpression" || !node.value.returnType)
+          return;
+        if (!isNullableUnion(node.value.returnType)) return;
+
+        const methodName =
+          node.key.type === "Identifier" ? node.key.name : "method";
+        if (isExceptionFunction(methodName)) return;
+
+        const baseType = getNonNullableType(node.value.returnType);
+
+        context.report({
+          node: node.value.returnType,
+          messageId: "noNullableReturn" as const,
+          data: { type: baseType },
+          // Disable auto-fix for method return types as it requires
+          // updating all return statements within the method body
+          fix: null,
+        });
+      },
+
+      // Check variable declarations with nullable union types
+      "VariableDeclarator[id.typeAnnotation]"(
+        node: TSESTree.VariableDeclarator,
+      ) {
+        if (node.id.type !== "Identifier" || !node.id.typeAnnotation) return;
+        if (!isNullableUnion(node.id.typeAnnotation)) return;
+
+        const baseType = getNonNullableType(node.id.typeAnnotation);
+
+        context.report({
+          node: node.id.typeAnnotation,
+          messageId: "noNullableUnion" as const,
+          data: { type: baseType },
+          // Disable auto-fix for variable declarations as it requires
+          // updating the variable initialization value
+          fix: null,
+        });
+      },
+
+      // Check calls to functions that might return null/undefined
+      CallExpression(node: TSESTree.CallExpression) {
+        // Skip if this is already an optional.from() or optional.from_async() call
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.object.type === "Identifier" &&
+          node.callee.object.name === "optional" &&
+          node.callee.property.type === "Identifier" &&
+          (node.callee.property.name === "from" ||
+            node.callee.property.name === "from_async")
+        ) {
+          return;
+        }
+
+        // Skip if this call is inside an optional.from() arrow function
+        let parent: TSESTree.Node = node.parent;
+        while (parent) {
+          if (
+            parent.type === "ArrowFunctionExpression" &&
+            parent.parent?.type === "CallExpression" &&
+            parent.parent.callee.type === "MemberExpression" &&
+            parent.parent.callee.object.type === "Identifier" &&
+            parent.parent.callee.object.name === "optional" &&
+            parent.parent.callee.property.type === "Identifier" &&
+            (parent.parent.callee.property.name === "from" ||
+              parent.parent.callee.property.name === "from_async")
+          ) {
+            return;
+          }
+          if (!parent.parent) break;
+          parent = parent.parent;
+        }
+
+        // Check for common nullable-returning functions
+        let functionName = "";
+        if (node.callee.type === "Identifier") {
+          functionName = node.callee.name;
+        } else if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.property.type === "Identifier"
+        ) {
+          functionName = node.callee.property.name;
+        }
+
+        // Common DOM/JS APIs that return null
+        const nullableAPIs = [
+          "getElementById",
+          "querySelector",
+          "getElementsByClassName",
+          "getElementsByTagName",
+          "find",
+          "pop",
+          "shift",
+          "match",
+        ];
+
+        if (nullableAPIs.includes(functionName)) {
+          context.report({
+            node,
+            messageId: "useOptionalFrom" as const,
+            fix: autoFix
+              ? (fixer) => {
+                const sourceCode = context.sourceCode;
+                const callText = sourceCode.getText(node);
+                return fixer.replaceText(
+                  node,
+                  `optional.from(() => ${callText})`,
+                );
+              }
+              : null,
+          });
+        }
+      },
+    };
+  },
+});
+
+export default enforceOptionalUsage;

--- a/src/optional/index.ts
+++ b/src/optional/index.ts
@@ -1,0 +1,12 @@
+/*
+Copyright (c) 2025 Allan Deutsch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+export { optional, type Optional } from './optional.ts';
+export { enforceOptionalUsage } from './eslint-rule.ts';

--- a/src/optional/optional.test.ts
+++ b/src/optional/optional.test.ts
@@ -276,6 +276,8 @@ test("Optional", async (t) => {
     });
 
     t.test("works with functions that conditionally return null", () => {
+      // Need this fn to return null to test that optional.from() works correctly
+      // eslint-disable-next-line ts-utils/enforce-optional-usage
       function findItem(id: number): string | null {
         return id === 1 ? "found" : null;
       }

--- a/src/optional/optional.test.ts
+++ b/src/optional/optional.test.ts
@@ -292,6 +292,7 @@ test("Optional", async (t) => {
 
     t.test("works with DOM-like APIs", () => {
       const mockDocument = {
+        // eslint-disable-next-line ts-utils/enforce-optional-usage
         getElementById: (id: string) => (id === "exists" ? { id } : null),
       };
 
@@ -371,10 +372,10 @@ test("Optional", async (t) => {
 
     t.test("works with fetch-like APIs", async () => {
       const mockFetch = async (url: string) => {
-        await new Promise((resolve) => setTimeout(resolve, 1));
         if (url === "/api/success") {
           return { ok: true, json: async () => ({ data: "success" }) };
         }
+        // eslint-disable-next-line ts-utils/enforce-optional-usage
         return { ok: false, json: async () => null };
       };
 

--- a/src/result/eslint-rule.test.ts
+++ b/src/result/eslint-rule.test.ts
@@ -122,6 +122,13 @@ ruleTester.run("enforce-result-usage", enforceResultUsage, {
       name: "Instance method calls are not detected (limitation)",
       code: `weakMap.set(primitive, value);`, // Instance methods not detected
     },
+    {
+      name: "Exception functions without wildcards are allowed",
+      code: `function exactName() {
+        throw new Error("Exact match exception");
+      }`,
+      options: [{ allowExceptions: ["exactName"] }],
+    },
   ],
 
   invalid: [
@@ -440,6 +447,36 @@ ruleTester.run("enforce-result-usage", enforceResultUsage, {
       ],
       output: `function testHelper() {
         return result.error(new Error("Test error"));
+      }`,
+    },
+
+    {
+      name: "Throw with non-Error object should wrap in Error",
+      code: `function handleError() {
+        throw { message: "Custom error object" };
+      }`,
+      errors: [
+        {
+          messageId: "noThrowStatement",
+        },
+      ],
+      output: `function handleError() {
+        return result.error(new Error({ message: "Custom error object" }));
+      }`,
+    },
+
+    {
+      name: "Throw with number should wrap in Error",
+      code: `function handleError() {
+        throw 404;
+      }`,
+      errors: [
+        {
+          messageId: "noThrowStatement",
+        },
+      ],
+      output: `function handleError() {
+        return result.error(new Error(404));
       }`,
     },
   ],

--- a/src/result/eslint-rule.test.ts
+++ b/src/result/eslint-rule.test.ts
@@ -1,0 +1,473 @@
+/*
+Copyright (c) 2025 Allan Deutsch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import { test } from "node:test";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { enforceResultUsage } from "./eslint-rule.ts";
+
+// Configure RuleTester for Node.js test environment
+RuleTester.afterAll = () => {};
+RuleTester.it = test;
+RuleTester.describe = (name: string, fn: () => void) => test(name, fn);
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+    },
+  },
+});
+
+ruleTester.run("enforce-result-usage", enforceResultUsage, {
+  valid: [
+    {
+      name: "Functions returning Result are valid",
+      code: `function parseJSON(text: string): Result<any, Error> {
+        return result.from(() => JSON.parse(text));
+      }`,
+    },
+    {
+      name: "Using result.from() for throwing calls is valid",
+      code: `const parsed = result.from(() => JSON.parse(jsonString));`,
+    },
+    {
+      name: "Using result.from() with block statement is valid",
+      code: `const data = result.from(() => {
+        const parsed = JSON.parse(input);
+        return parsed.value;
+      });`,
+    },
+    {
+      name: "Using result.from_async() for async operations is valid",
+      code: `const data = await result.from_async(() => fetch('/api/data'));`,
+    },
+    {
+      name: "Using result.error() instead of throw is valid",
+      code: `function validateInput(input: string): Result<string, Error> {
+        if (!input) {
+          return result.error(new Error("Input is required"));
+        }
+        return result.ok(input);
+      }`,
+    },
+    {
+      name: "Test files are allowed to use throw/try-catch by default",
+      code: `function testHelper() {
+        throw new Error("Test error");
+      }`,
+      filename: "test.spec.ts",
+    },
+    {
+      name: "Test files allow try-catch by default",
+      code: `try {
+        doSomething();
+      } catch (error) {
+        console.log(error);
+      }`,
+      filename: "src/component.test.ts",
+    },
+    {
+      name: "Exception functions are allowed",
+      code: `function allowedFunction() {
+        throw new Error("This is allowed");
+      }`,
+      options: [{ allowExceptions: ["allowedFunction"] }],
+    },
+    {
+      name: "Pattern exceptions are allowed",
+      code: `function debugHelper() {
+        throw new Error("Debug error");
+      }`,
+      options: [{ allowExceptions: ["debug*"] }],
+    },
+    {
+      name: "Already wrapped calls are valid",
+      code: `const parsed = result.from(() => {
+        return JSON.parse(data);
+      });`,
+    },
+    {
+      name: "Complex call expressions don't trigger rule",
+      code: `const result = obj[methodName]();`,
+    },
+    {
+      name: "Non-throwing member expressions are valid", 
+      code: `const max = Math.max(1, 2, 3);`,
+    },
+    {
+      name: "Function expressions don't trigger rule",
+      code: `const result = (function(){ return 42; })();`,
+    },
+    {
+      name: "Member expressions not in hardcoded list are not detected (limitation)",
+      code: `const trimmed = String.prototype.trim.call("  test  ");`,
+    },
+    {
+      name: "Call expression outside try block should exercise isInsideTryBlock false path", 
+      code: `function test() { const data = Math.random(); }`,
+    },
+    {
+      name: "Throwing member APIs not in hardcoded list are missed (known limitation)",
+      code: `const regex = new RegExp("invalid[");`, // This throws but won't be caught
+    },
+    {
+      name: "Instance method calls are not detected (limitation)",
+      code: `weakMap.set(primitive, value);`, // Instance methods not detected
+    },
+  ],
+
+  invalid: [
+    {
+      name: "Throw statements should be flagged",
+      code: `function validateInput(input: string) {
+        if (!input) {
+          throw new Error("Input is required");
+        }
+        return input;
+      }`,
+      errors: [
+        {
+          messageId: "noThrowStatement",
+        },
+      ],
+      output: `function validateInput(input: string) {
+        if (!input) {
+          return result.error(new Error("Input is required"));
+        }
+        return input;
+      }`,
+    },
+
+    {
+      name: "Throw with identifier",
+      code: `function processData() {
+        const error = new Error("Processing failed");
+        throw error;
+      }`,
+      errors: [
+        {
+          messageId: "noThrowStatement",
+        },
+      ],
+      output: `function processData() {
+        const error = new Error("Processing failed");
+        return result.error(error);
+      }`,
+    },
+
+    {
+      name: "Throw with string (should wrap in Error)",
+      code: `function handleError() {
+        throw "Something went wrong";
+      }`,
+      errors: [
+        {
+          messageId: "noThrowStatement",
+        },
+      ],
+      output: `function handleError() {
+        return result.error(new Error("Something went wrong"));
+      }`,
+    },
+
+    {
+      name: "Try/catch blocks should be flagged",
+      code: `function parseData(input: string) {
+        try {
+          const data = JSON.parse(input);
+          return data.value;
+        } catch (error) {
+          console.error(error);
+          return null;
+        }
+      }`,
+      errors: [
+        {
+          messageId: "noTryCatchBlock",
+        },
+      ],
+      output: `function parseData(input: string) {
+        const result = result.from(() => {
+          const data = JSON.parse(input);
+          return data.value;
+        });
+      }`,
+    },
+
+    {
+      name: "Try/catch with async operations",
+      code: `async function fetchData() {
+        try {
+          const response = await fetch('/api/data');
+          return await response.json();
+        } catch (error) {
+          return null;
+        }
+      }`,
+      errors: [
+        {
+          messageId: "noTryCatchBlock",
+        },
+      ],
+      output: `async function fetchData() {
+        const result = await result.from_async(async () => {
+          const response = await fetch('/api/data');
+          return await response.json();
+        });
+      }`,
+    },
+
+    {
+      name: "Direct JSON.parse call",
+      code: `const data = JSON.parse(jsonString);`,
+      errors: [
+        {
+          messageId: "useResultFrom",
+        },
+      ],
+      output: `const data = result.from(() => JSON.parse(jsonString));`,
+    },
+
+    {
+      name: "Direct parseInt call",
+      code: `const number = parseInt(userInput);`,
+      errors: [
+        {
+          messageId: "useResultFrom",
+        },
+      ],
+      output: `const number = result.from(() => parseInt(userInput));`,
+    },
+
+    {
+      name: "Direct atob call",
+      code: `const decoded = atob(encodedString);`,
+      errors: [
+        {
+          messageId: "useResultFrom",
+        },
+      ],
+      output: `const decoded = result.from(() => atob(encodedString));`,
+    },
+
+    {
+      name: "Direct fetch call (async)",
+      code: `const response = fetch('/api/data');`,
+      errors: [
+        {
+          messageId: "useResultFromAsync",
+        },
+      ],
+      output: `const response = result.from_async(() => fetch('/api/data'));`,
+    },
+
+    {
+      name: "Direct Proxy.revocable call",
+      code: `const proxy = Proxy.revocable({}, {});`,
+      errors: [
+        {
+          messageId: "useResultFrom",
+        },
+      ],
+      output: `const proxy = result.from(() => Proxy.revocable({}, {}));`,
+    },
+
+    {
+      name: "Direct Array.from call",
+      code: `const arr = Array.from({ length: -1 });`,
+      errors: [
+        {
+          messageId: "useResultFrom",
+        },
+      ],
+      output: `const arr = result.from(() => Array.from({ length: -1 }));`,
+    },
+
+    {
+      name: "Direct Object.defineProperty call",
+      code: `Object.defineProperty(obj, 'prop', { value: 42 });`,
+      errors: [
+        {
+          messageId: "useResultFrom",
+        },
+      ],
+      output: `result.from(() => Object.defineProperty(obj, 'prop', { value: 42 }));`,
+    },
+
+    {
+      name: "Direct String.fromCharCode call",
+      code: `const char = String.fromCharCode(0x110000);`,
+      errors: [
+        {
+          messageId: "useResultFrom",
+        },
+      ],
+      output: `const char = result.from(() => String.fromCharCode(0x110000));`,
+    },
+
+    {
+      name: "Direct Symbol.keyFor call",
+      code: `const key = Symbol.keyFor(notASymbol);`,
+      errors: [
+        {
+          messageId: "useResultFrom",
+        },
+      ],
+      output: `const key = result.from(() => Symbol.keyFor(notASymbol));`,
+    },
+
+    {
+      name: "Direct Reflect.get call",
+      code: `const value = Reflect.get(target, 'prop');`,
+      errors: [
+        {
+          messageId: "useResultFrom",
+        },
+      ],
+      output: `const value = result.from(() => Reflect.get(target, 'prop'));`,
+    },
+
+    {
+      name: "Multiple throwing calls in one statement",
+      code: `const result = {
+        parsed: JSON.parse(input1),
+        number: parseInt(input2)
+      };`,
+      errors: [
+        {
+          messageId: "useResultFrom",
+        },
+        {
+          messageId: "useResultFrom",
+        },
+      ],
+      output: `const result = {
+        parsed: result.from(() => JSON.parse(input1)),
+        number: result.from(() => parseInt(input2))
+      };`,
+    },
+
+    {
+      name: "Nested try/catch (disable auto-fix due to complex overlapping fixes)",
+      code: `function complexOperation() {
+        try {
+          const step1 = JSON.parse(input);
+          try {
+            const step2 = process(step1);
+            return step2;
+          } catch (innerError) {
+            throw new Error("Inner processing failed");
+          }
+        } catch (outerError) {
+          return null;
+        }
+      }`,
+      options: [{ autoFix: false }],
+      errors: [
+        {
+          messageId: "noTryCatchBlock",
+        },
+        {
+          messageId: "noTryCatchBlock",
+        },
+        {
+          messageId: "noThrowStatement",
+        },
+      ],
+    },
+
+    {
+      name: "Method with throw",
+      code: `class DataProcessor {
+        process(input: string) {
+          if (!input) {
+            throw new Error("Input required");
+          }
+          return input.toUpperCase();
+        }
+      }`,
+      errors: [
+        {
+          messageId: "noThrowStatement",
+        },
+      ],
+      output: `class DataProcessor {
+        process(input: string) {
+          if (!input) {
+            return result.error(new Error("Input required"));
+          }
+          return input.toUpperCase();
+        }
+      }`,
+    },
+
+    {
+      name: "Arrow function with throw",
+      code: `const validator = (input: string) => {
+        if (!input) throw new Error("Invalid input");
+        return input;
+      };`,
+      errors: [
+        {
+          messageId: "noThrowStatement",
+        },
+      ],
+      output: `const validator = (input: string) => {
+        if (!input) return result.error(new Error("Invalid input"));
+        return input;
+      };`,
+    },
+
+    {
+      name: "Test file with allowTestFiles: false",
+      code: `function testHelper() {
+        throw new Error("Test error");
+      }`,
+      filename: "test.spec.ts",
+      options: [{ allowTestFiles: false }],
+      errors: [
+        {
+          messageId: "noThrowStatement",
+        },
+      ],
+      output: `function testHelper() {
+        return result.error(new Error("Test error"));
+      }`,
+    },
+  ],
+});
+
+// Test with disabled auto-fix
+ruleTester.run("enforce-result-usage (no auto-fix)", enforceResultUsage, {
+  valid: [],
+  invalid: [
+    {
+      name: "Throw statement with autoFix disabled",
+      code: `throw new Error("Test");`,
+      options: [{ autoFix: false }],
+      errors: [
+        {
+          messageId: "noThrowStatement",
+        },
+      ],
+    },
+    {
+      name: "Try/catch block with autoFix disabled",
+      code: `try { doSomething(); } catch (e) { console.log(e); }`,
+      options: [{ autoFix: false }],
+      errors: [
+        {
+          messageId: "noTryCatchBlock",
+        },
+      ],
+    },
+  ],
+});

--- a/src/result/eslint-rule.ts
+++ b/src/result/eslint-rule.ts
@@ -301,35 +301,97 @@ export const enforceResultUsage = createRule<Options, MessageIds>({
           }
         };
 
-        // Simple traversal to detect await
-        const visited = new Set();
+        // Type-safe traversal to detect await
+        const visited = new Set<TSESTree.Node>();
         const traverse = (n: TSESTree.Node) => {
           if (visited.has(n)) return;
           visited.add(n);
 
           checkForAwait(n);
-          for (const key in n) {
-            if (key === "parent") continue; // Skip parent to avoid cycles
-            const value = (n as any)[key];
-            if (Array.isArray(value)) {
-              value.forEach((child) => {
-                if (
-                  child &&
-                  typeof child === "object" &&
-                  child.type &&
-                  !visited.has(child)
-                ) {
-                  traverse(child);
-                }
+          
+          // Use ESLint's visitor pattern for type-safe traversal
+          switch (n.type) {
+            case 'BlockStatement':
+              n.body.forEach(child => {
+                if (!visited.has(child)) traverse(child);
               });
-            } else if (
-              value &&
-              typeof value === "object" &&
-              value.type &&
-              !visited.has(value)
-            ) {
-              traverse(value);
-            }
+              break;
+            case 'IfStatement':
+              if (!visited.has(n.consequent)) traverse(n.consequent);
+              if (n.alternate && !visited.has(n.alternate)) traverse(n.alternate);
+              break;
+            case 'WhileStatement':
+            case 'DoWhileStatement':
+            case 'ForStatement':
+            case 'ForInStatement':
+            case 'ForOfStatement':
+              if (!visited.has(n.body)) traverse(n.body);
+              break;
+            case 'SwitchStatement':
+              n.cases.forEach(child => {
+                if (!visited.has(child)) traverse(child);
+              });
+              break;
+            case 'SwitchCase':
+              n.consequent.forEach(child => {
+                if (!visited.has(child)) traverse(child);
+              });
+              break;
+            case 'TryStatement':
+              if (!visited.has(n.block)) traverse(n.block);
+              if (n.handler && !visited.has(n.handler)) traverse(n.handler);
+              if (n.finalizer && !visited.has(n.finalizer)) traverse(n.finalizer);
+              break;
+            case 'CatchClause':
+              if (!visited.has(n.body)) traverse(n.body);
+              break;
+            case 'ExpressionStatement':
+              if (n.expression && !visited.has(n.expression)) traverse(n.expression);
+              break;
+            case 'AwaitExpression':
+              if (n.argument && !visited.has(n.argument)) traverse(n.argument);
+              break;
+            case 'CallExpression':
+              if (n.callee && !visited.has(n.callee)) traverse(n.callee);
+              n.arguments.forEach(arg => {
+                if (!visited.has(arg)) traverse(arg);
+              });
+              break;
+            case 'VariableDeclaration':
+              n.declarations.forEach(decl => {
+                if (!visited.has(decl)) traverse(decl);
+              });
+              break;
+            case 'VariableDeclarator':
+              if (n.init && !visited.has(n.init)) traverse(n.init);
+              break;
+            case 'ReturnStatement':
+              if (n.argument && !visited.has(n.argument)) traverse(n.argument);
+              break;
+            case 'AssignmentExpression':
+            case 'BinaryExpression':
+            case 'LogicalExpression':
+              if (n.left && !visited.has(n.left)) traverse(n.left);
+              if (n.right && !visited.has(n.right)) traverse(n.right);
+              break;
+            case 'ConditionalExpression':
+              if (n.test && !visited.has(n.test)) traverse(n.test);
+              if (n.consequent && !visited.has(n.consequent)) traverse(n.consequent);
+              if (n.alternate && !visited.has(n.alternate)) traverse(n.alternate);
+              break;
+            case 'MemberExpression':
+              if (n.object && !visited.has(n.object)) traverse(n.object);
+              if (n.computed && n.property && !visited.has(n.property)) traverse(n.property);
+              break;
+            default:
+              // For other node types, check if they have common properties
+              if ('body' in n && Array.isArray(n.body)) {
+                n.body.forEach((child: TSESTree.Node) => {
+                  if (!visited.has(child)) traverse(child);
+                });
+              } else if ('body' in n && n.body) {
+                if (!visited.has(n.body as TSESTree.Node)) traverse(n.body as TSESTree.Node);
+              }
           }
         };
 

--- a/src/result/eslint-rule.ts
+++ b/src/result/eslint-rule.ts
@@ -25,8 +25,8 @@ type MessageIds =
   | "useResultFromAsync";
 
 const createRule = ESLintUtils.RuleCreator(
-  (name) =>
-    `https://github.com/your-org/ts-utils/blob/main/docs/rules/${name}.md`,
+  () =>
+    `https://github.com/masstronaut/ts-utils/blob/main/src/result/readme.md`,
 );
 
 /**
@@ -295,31 +295,31 @@ export const enforceResultUsage = createRule<Options, MessageIds>({
 
         // Check if the try block contains async operations using simplified traversal
         let hasAwait = false;
-        
+
         function detectAwait(n: TSESTree.Node): void {
           if (n.type === "AwaitExpression") {
             hasAwait = true;
             return; // Found await, no need to continue
           }
-          
+
           if (hasAwait) return; // Early exit if already found
-          
+
           // Traverse child nodes using ESLint's visitor keys
           const visitorKeys = context.sourceCode.visitorKeys[n.type] || [];
           for (const key of visitorKeys) {
             const child = (n as unknown as Record<string, unknown>)[key];
             if (Array.isArray(child)) {
               child.forEach((item) => {
-                if (item && typeof item === 'object' && 'type' in item) {
+                if (item && typeof item === "object" && "type" in item) {
                   detectAwait(item as TSESTree.Node);
                 }
               });
-            } else if (child && typeof child === 'object' && 'type' in child) {
+            } else if (child && typeof child === "object" && "type" in child) {
               detectAwait(child as TSESTree.Node);
             }
           }
         }
-        
+
         detectAwait(node.block);
 
         context.report({

--- a/src/result/eslint-rule.ts
+++ b/src/result/eslint-rule.ts
@@ -1,0 +1,424 @@
+/*
+Copyright (c) 2025 Allan Deutsch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+
+type Options = [
+  {
+    allowExceptions?: string[];
+    allowTestFiles?: boolean;
+    autoFix?: boolean;
+  },
+];
+
+type MessageIds =
+  | "noThrowStatement"
+  | "noTryCatchBlock"
+  | "useResultFrom"
+  | "useResultFromAsync";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/your-org/ts-utils/blob/main/docs/rules/${name}.md`,
+);
+
+/**
+ * ESLint rule that enforces Result usage patterns instead of throw statements and try/catch blocks.
+ *
+ * This rule:
+ * - Disallows `throw` statements, suggesting `result.error()` instead
+ * - Disallows `try/catch` blocks, suggesting `result.from()` or `result.from_async()`
+ * - Detects calls to functions that throw and requires wrapping with `result.from()`
+ * - Provides auto-fix suggestions where possible
+ */
+export const enforceResultUsage = createRule<Options, MessageIds>({
+  name: "enforce-result-usage",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Enforce Result monad usage instead of throw statements and try/catch blocks",
+    },
+    fixable: "code",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowExceptions: {
+            type: "array",
+            items: { type: "string" },
+            description: "Function names or patterns to exclude from the rule",
+          },
+          allowTestFiles: {
+            type: "boolean",
+            description: "Allow throw/try-catch in test files",
+            default: true,
+          },
+          autoFix: {
+            type: "boolean",
+            description: "Enable automatic fixes",
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noThrowStatement:
+        "Use result.error() instead of throw statements for functional error handling. This ensures errors are part of the type system.",
+      noTryCatchBlock:
+        "Use result.from() or result.from_async() instead of try/catch blocks for type-safe error handling.",
+      useResultFrom:
+        "Calls to functions that may throw should be wrapped with result.from(). This ensures exceptions are handled safely.",
+      useResultFromAsync:
+        "Calls to async functions that may throw should be wrapped with result.from_async(). This ensures exceptions are handled safely.",
+    },
+  },
+  defaultOptions: [
+    { allowExceptions: [], allowTestFiles: true, autoFix: true },
+  ],
+  create(context, [options]) {
+    const {
+      allowExceptions = [],
+      allowTestFiles = true,
+      autoFix = true,
+    } = options;
+    const filename = context.filename;
+
+    function isTestFile(): boolean {
+      if (!allowTestFiles) return false;
+      return /\.test\.|\.spec\.|test\/|tests\/|__tests__/.test(filename);
+    }
+
+    function isExceptionFunction(name: string): boolean {
+      return allowExceptions.some((exception) => {
+        if (exception.includes("*")) {
+          const pattern = new RegExp(exception.replace(/\*/g, ".*"));
+          return pattern.test(name);
+        }
+        return exception === name;
+      });
+    }
+
+    function getFunctionName(node: TSESTree.CallExpression): string {
+      if (node.callee.type === "Identifier") {
+        return node.callee.name;
+      } else if (
+        node.callee.type === "MemberExpression" &&
+        node.callee.property.type === "Identifier"
+      ) {
+        return node.callee.property.name;
+      }
+      return "";
+    }
+
+    function isAlreadyWrappedInResult(node: TSESTree.Node): boolean {
+      if (node.parent === undefined) return false;
+      // Check if this call is already inside result.from() or result.from_async()
+      let parent: TSESTree.Node = node.parent;
+      while (parent) {
+        if (
+          parent.type === "ArrowFunctionExpression" &&
+          parent.parent?.type === "CallExpression" &&
+          parent.parent.callee.type === "MemberExpression" &&
+          parent.parent.callee.object.type === "Identifier" &&
+          parent.parent.callee.object.name === "result" &&
+          parent.parent.callee.property.type === "Identifier" &&
+          (parent.parent.callee.property.name === "from" ||
+            parent.parent.callee.property.name === "from_async")
+        ) {
+          return true;
+        }
+        if (parent.parent === undefined) return false;
+        parent = parent.parent;
+      }
+      return false;
+    }
+
+    function isInsideTryBlock(node: TSESTree.Node): boolean {
+      if (!node.parent) return false;
+
+      let parent: TSESTree.Node = node.parent;
+      while (parent) {
+        if (parent.type === "TryStatement") {
+          return true;
+        }
+
+        if (!parent.parent) break;
+        parent = parent.parent;
+      }
+      return false;
+    }
+
+    function isThrowingAPI(functionName: string): boolean {
+      // Common APIs that throw exceptions
+      const throwingAPIs = [
+        "parse",
+        "parseInt",
+        "parseFloat",
+        "atob",
+        "btoa",
+        "decodeURI",
+        "decodeURIComponent",
+        "fetch",
+        "require",
+        "import",
+        "readFileSync",
+        "writeFileSync",
+      ];
+      return throwingAPIs.includes(functionName);
+    }
+
+    function isThrowingMemberAPI(node: TSESTree.CallExpression): boolean {
+      // Check for member expressions like JSON.parse
+      if (
+        node.callee.type === "MemberExpression" &&
+        node.callee.object.type === "Identifier" &&
+        node.callee.property.type === "Identifier"
+      ) {
+        const objectName = node.callee.object.name;
+        const methodName = node.callee.property.name;
+
+        // Common throwing member APIs (not exhaustive - many more exist)
+        const throwingMemberAPIs = [
+          ["JSON", "parse"],
+          ["Proxy", "revocable"],
+          ["Array", "from"], // Can throw with invalid length
+          ["Object", "defineProperty"], // Can throw in various cases
+          ["Object", "setPrototypeOf"], // Can throw if non-extensible
+          ["String", "fromCharCode"], // Can throw RangeError for invalid code points
+          ["String", "fromCodePoint"], // Can throw RangeError for invalid code points
+          ["Symbol", "keyFor"], // Throws TypeError if not a symbol
+          ["Reflect", "get"], // Throws TypeError if target is not object
+          ["Reflect", "set"], // Throws TypeError if target is not object
+          ["Reflect", "defineProperty"], // Can throw TypeError
+          ["Reflect", "deleteProperty"], // Can throw TypeError
+          ["Reflect", "construct"], // Can throw TypeError
+          ["Reflect", "apply"], // Can throw TypeError
+          ["BigInt", "asIntN"], // Can throw RangeError for invalid bits
+          ["BigInt", "asUintN"], // Can throw RangeError for invalid bits
+        ];
+
+        return throwingMemberAPIs.some(
+          ([obj, method]) => objectName === obj && methodName === method,
+        );
+      }
+      return false;
+    }
+
+    function isAsyncFunction(node: TSESTree.CallExpression): boolean {
+      // Detect if this is likely an async call
+      const functionName = getFunctionName(node);
+      return (
+        functionName.includes("async") ||
+        functionName.includes("Async") ||
+        functionName.startsWith("fetch") ||
+        (/Sync$/.test(functionName) === false &&
+          ["fetch", "import", "readFile", "writeFile"].includes(functionName))
+      );
+    }
+
+    return {
+      // Detect throw statements
+      ThrowStatement(node: TSESTree.ThrowStatement) {
+        if (isTestFile()) return;
+
+        // Check if this throw is in an exception function
+        let current: TSESTree.Node = node.parent;
+        while (current) {
+          if (
+            [
+              "FunctionDeclaration",
+              "FunctionExpression",
+              "ArrowFunctionExpression",
+            ].includes(current.type)
+          ) {
+            const functionName =
+              (current.type === "FunctionDeclaration" && current.id?.name) ||
+              (current.parent?.type === "VariableDeclarator" &&
+                current.parent.id.type === "Identifier" &&
+                current.parent.id.name) ||
+              "anonymous";
+
+            if (isExceptionFunction(functionName)) return;
+            break;
+          }
+          if (!current.parent) break;
+          current = current.parent;
+        }
+
+        context.report({
+          node,
+          messageId: "noThrowStatement" as const,
+          fix: autoFix
+            ? (fixer) => {
+              const sourceCode = context.sourceCode;
+              const argumentText = sourceCode.getText(node.argument);
+
+              // Handle different types of throw arguments
+              if (
+                node.argument.type === "NewExpression" &&
+                node.argument.callee.type === "Identifier" &&
+                node.argument.callee.name === "Error"
+              ) {
+                return fixer.replaceText(
+                  node,
+                  `return result.error(${argumentText});`,
+                );
+              } else if (node.argument.type === "Identifier") {
+                return fixer.replaceText(
+                  node,
+                  `return result.error(${argumentText});`,
+                );
+              } else {
+                // Wrap non-Error values in Error constructor
+                return fixer.replaceText(
+                  node,
+                  `return result.error(new Error(${argumentText}));`,
+                );
+              }
+            }
+            : null,
+        });
+      },
+
+      // Detect try/catch blocks
+      TryStatement(node: TSESTree.TryStatement) {
+        if (isTestFile()) return;
+
+        // Check if the try block contains async operations
+        let hasAwait = false;
+        const checkForAwait = (n: TSESTree.Node) => {
+          if (n.type === "AwaitExpression") {
+            hasAwait = true;
+          }
+        };
+
+        // Simple traversal to detect await
+        const visited = new Set();
+        const traverse = (n: TSESTree.Node) => {
+          if (visited.has(n)) return;
+          visited.add(n);
+
+          checkForAwait(n);
+          for (const key in n) {
+            if (key === "parent") continue; // Skip parent to avoid cycles
+            const value = (n as any)[key];
+            if (Array.isArray(value)) {
+              value.forEach((child) => {
+                if (
+                  child &&
+                  typeof child === "object" &&
+                  child.type &&
+                  !visited.has(child)
+                ) {
+                  traverse(child);
+                }
+              });
+            } else if (
+              value &&
+              typeof value === "object" &&
+              value.type &&
+              !visited.has(value)
+            ) {
+              traverse(value);
+            }
+          }
+        };
+
+        traverse(node.block);
+
+        context.report({
+          node,
+          messageId: "noTryCatchBlock" as const,
+          fix: autoFix
+            ? (fixer) => {
+              const sourceCode = context.sourceCode;
+              const tryBlockText = sourceCode.getText(node.block);
+
+              // Remove braces from block and get inner content, preserving formatting
+              const innerContent = tryBlockText.slice(1, -1);
+
+              if (hasAwait) {
+                return fixer.replaceText(
+                  node,
+                  `const result = await result.from_async(async () => {${innerContent}});`,
+                );
+              } else {
+                return fixer.replaceText(
+                  node,
+                  `const result = result.from(() => {${innerContent}});`,
+                );
+              }
+            }
+            : null,
+        });
+      },
+
+      // Detect calls to functions that commonly throw
+      CallExpression(node: TSESTree.CallExpression) {
+        if (
+          isTestFile() ||
+          isAlreadyWrappedInResult(node) ||
+          isInsideTryBlock(node)
+        )
+          return;
+
+        // Skip if this is already a result.from() or result.from_async() call
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.object.type === "Identifier" &&
+          node.callee.object.name === "result" &&
+          node.callee.property.type === "Identifier" &&
+          (node.callee.property.name === "from" ||
+            node.callee.property.name === "from_async")
+        ) {
+          return;
+        }
+
+        const functionName = getFunctionName(node);
+        if (!functionName || isExceptionFunction(functionName)) return;
+
+        if (isThrowingAPI(functionName) || isThrowingMemberAPI(node)) {
+          const isAsync = isAsyncFunction(node);
+
+          context.report({
+            node,
+            messageId: isAsync
+              ? ("useResultFromAsync" as const)
+              : ("useResultFrom" as const),
+            fix: autoFix
+              ? (fixer) => {
+                const sourceCode = context.sourceCode;
+                const callText = sourceCode.getText(node);
+
+                if (isAsync) {
+                  return fixer.replaceText(
+                    node,
+                    `result.from_async(() => ${callText})`,
+                  );
+                } else {
+                  return fixer.replaceText(
+                    node,
+                    `result.from(() => ${callText})`,
+                  );
+                }
+              }
+              : null,
+          });
+        }
+      },
+
+      // Note: JSON.parse detection is now handled by the general CallExpression selector above
+    };
+  },
+});
+
+export default enforceResultUsage;

--- a/src/result/index.ts
+++ b/src/result/index.ts
@@ -1,0 +1,12 @@
+/*
+Copyright (c) 2025 Allan Deutsch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+export { result, type Result, type RetryError } from './result.ts';
+export { enforceResultUsage } from './eslint-rule.ts';

--- a/src/result/result.test.ts
+++ b/src/result/result.test.ts
@@ -60,7 +60,7 @@ test("Result", async (t) => {
     t.test("is_ok() narrows correctly in else branch", () => {
       const error = new Error("Test error");
       const errorResult = result.error<string, Error>(error);
-      
+
       if (errorResult.is_ok()) {
         assert.fail("Result should not be Ok");
       } else {
@@ -73,7 +73,7 @@ test("Result", async (t) => {
     t.test("is_error() narrows correctly in else branch", () => {
       const value = "Hello World";
       const okResult = result.ok<string, Error>(value);
-      
+
       if (okResult.is_error()) {
         assert.fail("Result should not be Error");
       } else {
@@ -88,7 +88,7 @@ test("Result", async (t) => {
         result.ok(42),
         result.error(new Error("Failed")),
         result.ok(0),
-        result.error(new Error("Another failure"))
+        result.error(new Error("Another failure")),
       ];
 
       const values: number[] = [];
@@ -110,21 +110,28 @@ test("Result", async (t) => {
       assert.strictEqual(errors[1]?.message, "Another failure");
     });
 
-    t.test("discriminated union preserves type information through chaining", () => {
-      const maybeNumber = result.ok<number, Error>(5);
-      
-      const processed = maybeNumber
-        .map(x => x * 2)
-        .and_then(x => x > 8 ? result.ok(x.toString()) : result.error(new Error("Too small")));
+    t.test(
+      "discriminated union preserves type information through chaining",
+      () => {
+        const maybeNumber = result.ok<number, Error>(5);
 
-      if (processed.is_ok()) {
-        // TypeScript knows this is string
-        assert.strictEqual(processed.value, "10");
-        assert.strictEqual(processed.value.length, 2);
-      } else {
-        assert.fail("Should have been Ok");
-      }
-    });
+        const processed = maybeNumber
+          .map((x) => x * 2)
+          .and_then((x) =>
+            x > 8
+              ? result.ok(x.toString())
+              : result.error(new Error("Too small")),
+          );
+
+        if (processed.is_ok()) {
+          // TypeScript knows this is string
+          assert.strictEqual(processed.value, "10");
+          assert.strictEqual(processed.value.length, 2);
+        } else {
+          assert.fail("Should have been Ok");
+        }
+      },
+    );
   });
 
   t.test("Value/Error Access", async (t) => {
@@ -391,12 +398,6 @@ test("Result", async (t) => {
         assert.strictEqual(errorResult.error.code, 404);
         assert.strictEqual(errorResult.error.message, "Custom error");
       }
-    });
-
-    t.test("asserts construction invariant", () => {
-      const Constructor = result.ok(1).constructor as any;
-      assert.throws(() => new Constructor({}));
-      assert.throws(() => new Constructor({ ok: 1, error: new Error() }));
     });
   });
 

--- a/src/result/result.test.ts
+++ b/src/result/result.test.ts
@@ -37,31 +37,31 @@ test("Result", async (t) => {
 
     t.test("constructor validates arguments defensively", () => {
       const okResult = result.ok("test");
+      // Since the ResultImpl is not part of the public interface,
+      // we are doing some funny business to access the constructor and test invariants.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const ResultConstructor = (okResult as any).constructor;
 
       assert.throws(
         () => new ResultConstructor({ ok: "value", error: new Error("both") }),
         {
           name: "TypeError",
-          message: "Result must be constructed with either an 'ok' or 'error' property.",
+          message:
+            "Result must be constructed with either an 'ok' or 'error' property.",
         },
       );
 
-      assert.throws(
-        () => new ResultConstructor({}),
-        {
-          name: "TypeError", 
-          message: "Result must be constructed with either an 'ok' or 'error' property.",
-        },
-      );
+      assert.throws(() => new ResultConstructor({}), {
+        name: "TypeError",
+        message:
+          "Result must be constructed with either an 'ok' or 'error' property.",
+      });
 
-      assert.throws(
-        () => new ResultConstructor({ something: "else" }),
-        {
-          name: "TypeError",
-          message: "Result must be constructed with either an 'ok' or 'error' property.",
-        },
-      );
+      assert.throws(() => new ResultConstructor({ something: "else" }), {
+        name: "TypeError",
+        message:
+          "Result must be constructed with either an 'ok' or 'error' property.",
+      });
     });
   });
 

--- a/src/result/result.test.ts
+++ b/src/result/result.test.ts
@@ -34,6 +34,35 @@ test("Result", async (t) => {
         assert.strictEqual(undefinedOkResult.value, undefined);
       }
     });
+
+    t.test("constructor validates arguments defensively", () => {
+      const okResult = result.ok("test");
+      const ResultConstructor = (okResult as any).constructor;
+
+      assert.throws(
+        () => new ResultConstructor({ ok: "value", error: new Error("both") }),
+        {
+          name: "TypeError",
+          message: "Result must be constructed with either an 'ok' or 'error' property.",
+        },
+      );
+
+      assert.throws(
+        () => new ResultConstructor({}),
+        {
+          name: "TypeError", 
+          message: "Result must be constructed with either an 'ok' or 'error' property.",
+        },
+      );
+
+      assert.throws(
+        () => new ResultConstructor({ something: "else" }),
+        {
+          name: "TypeError",
+          message: "Result must be constructed with either an 'ok' or 'error' property.",
+        },
+      );
+    });
   });
 
   t.test("Type Predicates & Narrowing", async (t) => {

--- a/src/result/result.ts
+++ b/src/result/result.ts
@@ -353,6 +353,7 @@ class ResultImpl<ResultType, ErrorType extends Error>
       this.error = result.error;
       this.value = none_value;
     } else {
+      // eslint-disable-next-line ts-utils/enforce-result-usage
       throw new TypeError(
         "Result must be constructed with either an 'ok' or 'error' property.",
       );
@@ -578,6 +579,8 @@ const result = Object.freeze({
    * ```
    */
   from: <T>(fn: () => T): Result<T, Error> => {
+    // need to use try/catch to wrap throwing functions in results.
+    // eslint-disable-next-line ts-utils/enforce-result-usage
     try {
       return ResultImpl.ok(fn());
     } catch (error) {
@@ -622,6 +625,8 @@ const result = Object.freeze({
    * ```
    */
   from_async: async <T>(fn: () => Promise<T>): Promise<Result<T, Error>> => {
+    // need to use try/catch to wrap throwing functions in results.
+    // eslint-disable-next-line ts-utils/enforce-result-usage
     try {
       const value = await fn();
       return ResultImpl.ok(value);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "allowUnreachableCode": false,
+    "noImplicitAny": true,
     /* Node Stuff */
     "erasableSyntaxOnly": true,
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Summary
- Add comprehensive ESLint rules to enforce Optional and Result usage patterns
- Implement `enforce-optional-usage` rule to prevent nullable types and suggest `optional.from()`
- Implement `enforce-result-usage` rule to prevent throw/try-catch and suggest `result.from()`
- Include extensive test coverage and auto-fix capabilities for both rules

## Changes
- **ESLint Configuration**: Complete flat config setup with TypeScript support
- **Optional Rule**: Detects nullable returns, variables, and function calls with auto-fix for common APIs
- **Result Rule**: Detects throw statements, try/catch blocks, and throwing function calls with auto-fix
- **Test Coverage**: 100% coverage for both rules with comprehensive test suites
- **Documentation**: Updated readmes with detailed rule usage and configuration examples
- **Development Tooling**: Added lint scripts and proper ESLint integration

## Test plan
- [x] All existing tests pass with new linting rules
- [x] ESLint rules have comprehensive test coverage using @typescript-eslint/rule-tester
- [x] Auto-fix functionality works correctly for supported violations
- [x] Rules properly handle edge cases and exception patterns
- [x] Integration with existing codebase maintains backward compatibility